### PR TITLE
Add example of dots within ligatures

### DIFF
--- a/_tests/ligature/ligature-047.mei
+++ b/_tests/ligature/ligature-047.mei
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Ligatures</title>
+         </titleStmt>
+         <pubStmt>
+            <date>2020-04-09</date>
+         </pubStmt>
+         <notesStmt>
+            <annot>Ligature example. SB-SB </annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="unknown">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" notationtype="mensural.white" lines="5" clef.shape="F" clef.line="4" />
+                     <staffDef n="2" notationtype="mensural.black" lines="5" clef.shape="F" clef.line="4" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <staff n="1">
+                     <layer n="1">
+                        <ligature>
+                            <note pname="d" oct="3" dur="brevis"/>
+                            <dot/>
+                            <note pname="a" oct="3" dur="brevis"/>
+                            <note pname="d" oct="3" dur="brevis"/>
+                        </ligature>
+                        <ligature form="obliqua">
+                            <note pname="f" oct="3" dur="semibrevis"/>
+                            <note pname="e" oct="3" dur="semibrevis"/>
+                            <dot/>
+                        </ligature>
+                        <ligature form="obliqua">
+                            <note pname="a" oct="3" dur="semibrevis"/>
+                            <dot/>
+                            <note pname="d" oct="3" dur="semibrevis"/>
+                            <dot/>
+                        </ligature>
+                        <ligature>
+                            <note pname="d" oct="3" dur="semibrevis"/>
+                            <dot/>
+                            <note pname="g" oct="3" dur="semibrevis"/>
+                        </ligature>
+                        <ligature>
+                            <note pname="g" oct="2" dur="brevis"/>
+                            <note pname="f" oct="3" dur="brevis"/>
+                            <note pname="g" oct="3" dur="brevis"/>
+                            <note pname="d" oct="3" dur="longa"/>
+                            <dot/>
+                        </ligature>
+                     </layer>
+                  </staff>
+                  <staff n="2">
+                     <layer n="1">
+                        <ligature>
+                            <note pname="d" oct="3" dur="brevis"/>
+                            <dot/>
+                            <note pname="a" oct="3" dur="brevis"/>
+                            <note pname="d" oct="3" dur="brevis"/>
+                        </ligature>
+                        <ligature form="obliqua">
+                            <note pname="f" oct="3" dur="semibrevis"/>
+                            <note pname="e" oct="3" dur="semibrevis"/>
+                            <dot/>
+                        </ligature>
+                        <ligature form="obliqua">
+                            <note pname="a" oct="3" dur="semibrevis"/>
+                            <dot/>
+                            <note pname="d" oct="3" dur="semibrevis"/>
+                            <dot/>
+                        </ligature>
+                        <ligature>
+                            <note pname="d" oct="3" dur="semibrevis"/>
+                            <dot/>
+                            <note pname="g" oct="3" dur="semibrevis"/>
+                        </ligature>
+                        <ligature>
+                            <note pname="g" oct="2" dur="brevis"/>
+                            <note pname="f" oct="3" dur="brevis"/>
+                            <note pname="g" oct="3" dur="brevis"/>
+                            <note pname="d" oct="3" dur="longa"/>
+                            <dot/>
+                        </ligature>
+                     </layer>
+                  </staff>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>
+


### PR DESCRIPTION
This is an example of the encoding of the ligatures shown in the following images. The dots are not being rendered so far.

![1 2](https://user-images.githubusercontent.com/13948831/99819894-10744280-2b1e-11eb-87e5-5d6e48f64b7c.png)
![3](https://user-images.githubusercontent.com/13948831/99819901-123e0600-2b1e-11eb-887d-b26338f4d761.png)
![4](https://user-images.githubusercontent.com/13948831/99819913-18cc7d80-2b1e-11eb-919b-809e122c6feb.png)
![5](https://user-images.githubusercontent.com/13948831/99820352-a8722c00-2b1e-11eb-83d4-71079e74ec3f.png)

