### PR TITLE
Fix HTML errors and warnings

### DIFF
--- a/_layouts/comparison.html
+++ b/_layouts/comparison.html
@@ -17,10 +17,10 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/css/verovio-sidebar.css" />
     
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="{{ site.baseurl }}/javascript/jquery.min.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/javascript/bootstrap.min.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/javascript/FileSaver.min.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/javascript/jquery.cookie.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/javascript/jquery.min.js"></script>
+    <script src="{{ site.baseurl }}/javascript/bootstrap.min.js"></script>
+    <script src="{{ site.baseurl }}/javascript/FileSaver.min.js"></script>
+    <script src="{{ site.baseurl }}/javascript/jquery.cookie.js"></script>
 </head>
 
 <body>

--- a/_layouts/verovio.html
+++ b/_layouts/verovio.html
@@ -4,24 +4,24 @@ layout: default
 
 <div>
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="{{ site.baseurl }}/javascript/carousel.js" type="text/javascript" ></script>
-    <script src="{{ site.baseurl }}/javascript/jquery.touchSwipe.min.js" type="text/javascript" ></script>
-    <script src="{{ site.baseurl }}/javascript/fileinput.js" type="text/javascript" ></script>
+    <script src="{{ site.baseurl }}/javascript/carousel.js"></script>
+    <script src="{{ site.baseurl }}/javascript/jquery.touchSwipe.min.js"></script>
+    <script src="{{ site.baseurl }}/javascript/fileinput.js"></script>
     {% if page.verovio-light %}
-    <script src="{{ site.baseurl }}/javascript/develop/verovio-toolkit-light.js" type="text/javascript" ></script>
+    <script src="{{ site.baseurl }}/javascript/develop/verovio-toolkit-light.js"></script>
     {% elsif page.verovio-hum %}
-    <script src="{{ site.baseurl }}/javascript/develop/verovio-toolkit-hum.js" type="text/javascript" ></script>
+    <script src="{{ site.baseurl }}/javascript/develop/verovio-toolkit-hum.js"></script>
     {% elsif page.verovio != false %}
-    <script src="{{ site.baseurl }}/javascript/develop/verovio-toolkit.js" type="text/javascript" ></script>
+    <script src="{{ site.baseurl }}/javascript/develop/verovio-toolkit.js"></script>
     {% endif %}
     <!-- midi-player -->
     {% if page.midiplayer %}
-    <script src="{{ site.baseurl }}/javascript/midi-player/wildwebmidi.js" type="text/javascript"></script>
-    <script src="{{ site.baseurl }}/javascript/midi-player/midiplayer.js" type="text/javascript"></script>
+    <script src="{{ site.baseurl }}/javascript/midi-player/wildwebmidi.js"></script>
+    <script src="{{ site.baseurl }}/javascript/midi-player/midiplayer.js"></script>
     {% endif %}
-    <!--script src="{{ site.baseurl }}/javascript/canvg/rgbcolor.js" type="text/javascript" ></script-->
-    <!--script src="{{ site.baseurl }}/javascript/canvg/StackBlur.js" type="text/javascript" ></script-->
-    <!--script src="{{ site.baseurl }}/javascript/canvg/canvg.js" type="text/javascript" ></script-->
+    <!--script src="{{ site.baseurl }}/javascript/canvg/rgbcolor.js"></script-->
+    <!--script src="{{ site.baseurl }}/javascript/canvg/StackBlur.js"></script-->
+    <!--script src="{{ site.baseurl }}/javascript/canvg/canvg.js"></script-->
 </div>
 <div>
     {{ content }}

--- a/comparison.xhtml
+++ b/comparison.xhtml
@@ -84,7 +84,7 @@ versions:
 <div class="container-fluid tests">
     <div class="row header-tests">
         <div class="col-lg-12">
-                <a class="navbar-brand logo-nav" href="{{ site.baseurl }}/index.xhtml"><img src="{{ site.baseurl }}/images/verovio-fadded-50.png" /></a>
+                <a class="navbar-brand logo-nav" href="{{ site.baseurl }}/index.xhtml"><img alt="Verovio logo" src="{{ site.baseurl }}/images/verovio-fadded-50.png" /></a>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: null
+title: Verovio
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/index.html
+++ b/index.html
@@ -2,9 +2,8 @@
 layout: null
 ---
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Verovio</title>
     {% seo %}
     <meta http-equiv="refresh" content="0; URL=index.xhtml"/>
 </head>

--- a/index.xhtml
+++ b/index.xhtml
@@ -112,7 +112,7 @@ projects:
         <p>
             Many thanks to all the contributors
         </p>
-        <img class="img-responsive" src="https://contrib.rocks/image?repo=rism-digital/verovio" />
+        <img alt="contributors" class="img-responsive" src="https://contrib.rocks/image?repo=rism-digital/verovio" />
 
 
     </div>
@@ -166,7 +166,7 @@ projects:
             <table align="center">
                 <tr>
                     <td>
-                        <img src="{{ site.baseurl }}/images/interaction.png" style="padding: 10px;" class="img-responsive"/>
+                        <img alt="Verovio interaction" src="{{ site.baseurl }}/images/interaction.png" style="padding: 10px;" class="img-responsive"/>
                     </td>
                 </tr>
             </table>
@@ -186,7 +186,7 @@ projects:
         </div>
     </div>
     <div class="col-sm-3 hidden-xs">
-        <img src="{{ site.baseurl }}/images/mobiles.png" class="img-responsive"/>
+        <img alt="mobile devices" src="{{ site.baseurl }}/images/mobiles.png" class="img-responsive"/>
     </div>
 </div>
 
@@ -202,7 +202,7 @@ projects:
                     <td align="center">
                     {%- if p != empty -%}
                            <a href="{{ p[0] }}" target="_blank">
-                               <img src="{{ site.baseurl }}/images/projects/{{ p[1] }}.png" style="padding: 10px" class="img-responsive"/>
+                               <img alt="project logo" src="{{ site.baseurl }}/images/projects/{{ p[1] }}.png" style="padding: 10px" class="img-responsive"/>
                            </a>
                     {%- endif -%}
                     </td>

--- a/index.xhtml
+++ b/index.xhtml
@@ -75,7 +75,6 @@ projects:
         </p>
 
         <div style="float: right;">
-            <!-- Place this tag where you want the button to render. -->
             <a class="github-button" href="https://github.com/rism-digital/verovio/subscription" data-icon="octicon-eye" data-size="large" data-show-count="false" aria-label="Watch rism-digital/verovio on GitHub">Watch</a>
             <a class="github-button" href="https://github.com/rism-digital/verovio" data-icon="octicon-star" data-size="large" data-show-count="false" aria-label="Star rism-digital/verovio on GitHub">Star</a>
         </div>
@@ -101,7 +100,7 @@ projects:
                         <img alt="Mozarteum logo" src="{{ site.baseurl }}/images/mozarteum.png" class="support-logo img-responsive"/>
                     </a>
                 </td>
-                <!--><td>
+                <!--<td>
                     <a href="http://www.mozarteum.at" target="_blank">
                         <img alt="SNF logo" src="{{ site.baseurl }}/images/saw.png" class="support-logo img-responsive"/>
                     </a>
@@ -132,25 +131,25 @@ projects:
             <!-- Wrapper for slides -->
             <div class="carousel-inner" role="listbox">
                 <div class="item">
-                    <video autoplay="false" loop="true" class="img-responsive">
+                    <video autoplay="autoplay" loop="loop" class="img-responsive">
                         <source src="/movies/editor.webm" type="video/webm"/>
                         <source src="/movies/editor.mp4" type="video/mp4"/>
                     </video>
                 </div>
                 <div class="item">
-                    <video autoplay="false" loop="true" class="img-responsive">
+                    <video autoplay="autoplay" loop="loop" class="img-responsive">
                         <source src="/movies/reflow.webm" type="video/webm"/>
                         <source src="/movies/reflow.mp4" type="video/mp4"/>
                     </video>
                 </div>
                 <div class="item">
-                    <video autoplay="false" loop="true" class="img-responsive">
+                    <video autoplay="autoplay" loop="loop" class="img-responsive">
                         <source src="/movies/layout.webm" type="video/webm"/>
                         <source src="/movies/layout.mp4" type="video/mp4"/>
                     </video>
                 </div>
                 <div class="item">
-                    <video autoplay="false" loop="true" class="img-responsive">
+                    <video autoplay="autoplay" loop="loop" class="img-responsive">
                         <source src="/movies/choice.webm" type="video/webm"/>
                         <source src="/movies/choice.mp4" type="video/mp4"/>
                     </video>
@@ -234,8 +233,8 @@ projects:
     </div>
 </div>
 
-<script async="true" defer="true" src="https://buttons.github.io/buttons.js"></script>
-<script type="text/javascript">
+<script async="async" defer="defer" src="https://buttons.github.io/buttons.js"></script>
+<script>
 //<![CDATA[
     $( document ).ready(function() {
         rand = Math.floor( Math.random() * 4);

--- a/index.xhtml
+++ b/index.xhtml
@@ -25,7 +25,7 @@ projects:
             <p>
                 Verovio follows the <strong>Standard Music Font Layout</strong> specification, which makes it easy to change the music font for <a href="{{ site.baseurl }}/smufl.xhtml">personalizing the appearance</a>.
             </p>
-            <table align="center">
+            <table style="margin: auto;">
                 <tr>
                     <td>
                         <a href="http://music-encoding.org" target="_blank">
@@ -84,7 +84,7 @@ projects:
             The source code is available on <a href="https://github.com/rism-digital/verovio">GitHub</a> under the <a href="http://www.gnu.org/copyleft/lgpl.html" target="_blank">LGPLv3 license</a>.
         </p>
 
-        <table align="center">
+        <table style="margin: auto;">
             <tr>
                 <td>
                     <a href="https://rism.digital" target="_blank">
@@ -163,7 +163,7 @@ projects:
             <p>
                 The SVG output of Verovio is designed as an <strong>intermediate reflowable layer</strong> that facilitates the development of <strong>interactive applications</strong>, such as music notation editors or interactive digital editions.
             </p>
-            <table align="center">
+            <table style="margin: auto;">
                 <tr>
                     <td>
                         <img alt="Verovio interaction" src="{{ site.baseurl }}/images/interaction.png" style="padding: 10px;" class="img-responsive"/>
@@ -195,11 +195,11 @@ projects:
         <p>
             Verovio is designed to be used in a wide range of applications and has been adopted by several projects or institutions. It is currently used by:
         </p>
-        <table align="center">
+        <table style="margin: auto;">
             {% for line in page.projects %}
             <tr>
                 {% for p in line %}
-                    <td align="center">
+                    <td style="margin: auto;">
                     {%- if p != empty -%}
                            <a href="{{ p[0] }}" target="_blank">
                                <img alt="project logo" src="{{ site.baseurl }}/images/projects/{{ p[1] }}.png" style="padding: 10px" class="img-responsive"/>
@@ -224,7 +224,7 @@ projects:
         </p>
     </div>
     <div class="col-sm-4 hidden-xs">
-        <table align="center">
+        <table style="margin: auto;">
             <tr>
                 <td>
                     <img alt="Verovio canon" src="{{ site.baseurl }}/images/verovio-canon.png" class="img-responsive"/>

--- a/mei-player.xhtml
+++ b/mei-player.xhtml
@@ -343,7 +343,7 @@ downloads:
         <span class="glyphicon glyphicon-download"></span><span> MEI</span>
     </button>
     <a class="navbar-brand logo-nav" href="{{ site.baseurl }}/index.xhtml">
-        <img src="{{ site.baseurl }}/images/verovio-fadded-50.png" />
+        <img alt="Verovio logo" src="{{ site.baseurl }}/images/verovio-fadded-50.png" />
     </a>
     <div style="clear: both;"></div>
     <hr/>

--- a/mei-viewer-wasm.xhtml
+++ b/mei-viewer-wasm.xhtml
@@ -514,7 +514,7 @@ downloads:
             <span class="glyphicon glyphicon-download"></span><span> MEI</span>
         </button>
         <a class="navbar-brand logo-nav" href="{{ site.baseurl }}/index.xhtml">
-            <img src="{{ site.baseurl }}/images/verovio-fadded-50.png" />
+            <img alt="Verovio logo" src="{{ site.baseurl }}/images/verovio-fadded-50.png" />
         </a>
         <div style="clear: both;"></div>
         <hr/>

--- a/mei-viewer.xhtml
+++ b/mei-viewer.xhtml
@@ -633,7 +633,7 @@ downloads:
             <span class="glyphicon glyphicon-download"></span><span> MEI</span>
         </button>
         <a class="navbar-brand logo-nav" href="{{ site.baseurl }}/index.xhtml">
-            <img src="{{ site.baseurl }}/images/verovio-fadded-50.png" />
+            <img alt="Verovio logo" src="{{ site.baseurl }}/images/verovio-fadded-50.png" />
         </a>
         <div style="clear: both;"></div>
         <hr/>

--- a/pae-editor.xhtml
+++ b/pae-editor.xhtml
@@ -127,7 +127,7 @@ version-footer: true
                             <area shape="rect" coords="476,3,500,152" href="javascript:onpitch('A', 3, 0, 93)" />
                             <area shape="rect" coords="501,3,525,152" href="javascript:onpitch('B', 3, 0, 95)" />
                         </map>
-                        <img id="piano_img" src="{{ site.baseurl }}/images/piano.png" usemap="#piano_map"/>
+                        <img alt="piano keyboard" id="piano_img" src="{{ site.baseurl }}/images/piano.png" usemap="#piano_map"/>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
This PR fixes some HTML errors and warnings:
* remove `title` tag, because `jekyll-seo-tag` creates another one
* add `lang` attribute to `html` tag
* remove unneeded `type` attribute on `script` tags
* add a needed alt attribute to `img` tags