### PR TITLE
Add lute tablature test files

### DIFF
--- a/_tests/tab/tab-001.mei
+++ b/_tests/tab/tab-001.mei
@@ -1,0 +1,243 @@
+<?xml version="1.0" standalone="no"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title>French lute tablature example</title>
+            </titleStmt>
+            <pubStmt>
+                <respStmt>
+                    <persName role="encoder">Olja Janjuš</persName>
+                </respStmt>
+                <date isodate="2024-12-04" />
+            </pubStmt>
+            <notesStmt>
+                <annot>Lute tablature rendering</annot>
+            </notesStmt>
+            <sourceDesc>
+                <source>
+                    <bibl>
+                        <title>A galliard made by Ed.J.</title>
+                        <title type="main">A new Booke of Tabliture for the Orpharion</title>
+                        <composer>Edward Johnson</composer>
+                        <arranger>William Barley</arranger>
+                        <date isodate="1596">1596</date>
+                        <locus>C1v</locus>
+                    </bibl>
+                </source>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <appInfo>
+                <application isodate="2022-09-26" version="1.4.5">
+                    <name>luteconv</name>
+                </application>
+            </appInfo>
+        </encodingDesc>
+        <workList>
+            <work>
+                <title>A galliard made by Ed.J.</title>
+                <composer>Edward Johnson</composer>
+            </work>
+        </workList>
+    </meiHead>
+    <music>
+        <body>
+            <mdiv n="1">
+                <score>
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef n="1" lines="6" notationtype="tab.lute.french">
+                                <tuning>
+                                    <course n="1" pname="g" oct="4" />
+                                    <course n="2" pname="d" oct="4" />
+                                    <course n="3" pname="a" oct="3" />
+                                    <course n="4" pname="f" oct="3" />
+                                    <course n="5" pname="c" oct="3" />
+                                    <course n="6" pname="g" oct="2" />
+                                    <course n="7" pname="f" oct="2" />
+                                </tuning>
+                            </staffDef>
+                        </staffGrp>
+                    </scoreDef>
+                    <section n="1">
+                        <measure n="18">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <beam>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="4" tab.fret="0" />
+                                        </tabGrp>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="1" tab.fret="0" xml:id="id7" />
+                                        </tabGrp>
+                                    </beam>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="2" xml:id="id8" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id7" />
+                            <ornam ho="-2" startid="#id8">#</ornam>
+                        </measure>
+                        <measure n="19">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="2" />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="5" tab.fret="0" />
+                                    </tabGrp>
+                                    <beam>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="1" tab.fret="0" xml:id="id9" />
+                                        </tabGrp>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="5" tab.fret="2" />
+                                        </tabGrp>
+                                    </beam>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="5" tab.fret="3" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="2" startid="#id9" />
+                        </measure>
+                        <measure n="20">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="0" />
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="0" />
+                                        <note tab.course="6" tab.fret="3" />
+                                    </tabGrp>
+                                    <beam>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="5" tab.fret="2" xml:id="id10" />
+                                        </tabGrp>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="2" tab.fret="2" xml:id="id11" />
+                                        </tabGrp>
+                                    </beam>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="3" xml:id="id12" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id11" />
+                            <line startid="#id10" endid="#id12" />
+                        </measure>
+                        <measure n="21">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="4" tab.fret="0" />
+                                        <note tab.course="6" tab.fret="2" />
+                                    </tabGrp>
+                                    <beam>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="5" tab.fret="0" />
+                                        </tabGrp>
+                                        <tabGrp dur="16">
+                                            <tabDurSym />
+                                            <note tab.course="2" tab.fret="0" xml:id="id13" />
+                                        </tabGrp>
+                                    </beam>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="1" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id13" />
+                        </measure>
+                        <measure n="22">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8" dots="1">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="2" />
+                                        <note tab.course="6" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="6" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <note tab.course="2" tab.fret="0" />
+                                        <note tab.course="6" tab.fret="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <note tab.course="2" tab.fret="2" />
+                                        <note tab.course="5" tab.fret="0" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure n="23">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="5" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="2" tab.fret="2" xml:id="id14" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id14" />
+                        </measure>
+                        <measure n="24" right="rptend">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="4" xml:id="id15">
+                                        <tabDurSym />
+                                        <note tab.course="7" tab.fret="0" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fermata startid="#id15" />
+                        </measure>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/_tests/tab/tab-002.mei
+++ b/_tests/tab/tab-002.mei
@@ -1,0 +1,191 @@
+<?xml version="1.0" standalone="no"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title>German lute tablature example</title>
+            </titleStmt>
+            <pubStmt>
+                <respStmt>
+                    <persName role="encoder">Olja Janjuš</persName>
+                </respStmt>
+                <date isodate="2024-12-04" />
+            </pubStmt>
+            <notesStmt>
+                <annot>Lute tablature rendering</annot>
+            </notesStmt>
+            <sourceDesc>
+                <source>
+                    <bibl>
+                        <title>Elslein liebes Elslein.</title>
+                        <title type="main">Ain schone kunstliche Underweisung</title>
+                        <author>Hans Judenkünig</author>
+                        <date>1523</date>
+                        <locus>22v</locus>
+                    </bibl>
+                </source>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <appInfo>
+                <application isodate="2023-12-15" version="1.4.7">
+                    <name>luteconv</name>
+                </application>
+            </appInfo>
+        </encodingDesc>
+        <workList>
+            <work>
+                <title>Elslein liebes Elslein.</title>
+                <composer>Hans Judenkünig</composer>
+            </work>
+        </workList>
+    </meiHead>
+    <music>
+        <body>
+            <mdiv n="1">
+                <score>
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef n="1" lines="3" notationtype="tab.lute.german"
+                                tab.align="bottom">
+                                <mensur sign="C" num="3" />
+                                <tuning>
+                                    <course n="1" pname="a" oct="4" />
+                                    <course n="2" pname="e" oct="4" />
+                                    <course n="3" pname="b" oct="3" />
+                                    <course n="4" pname="g" oct="3" />
+                                    <course n="5" pname="d" oct="3" />
+                                    <course n="6" pname="a" oct="2" />
+                                </tuning>
+                            </staffDef>
+                        </staffGrp>
+                    </scoreDef>
+                    <section n="1">
+                        <measure n="1">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym tab.line="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <tabDurSym tab.line="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="0" />
+                                        <note tab.course="4" tab.fret="2" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure n="2">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="0" />
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="2" tab.fret="3" xml:id="id0" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="2" xml:id="id1" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="0" xml:id="id2" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id0" />
+                            <fing playingHand="right" playingFinger="1" startid="#id1" />
+                            <fing playingHand="right" playingFinger="1" startid="#id2" />
+                        </measure>
+                        <measure n="3">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="2" />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="2" xml:id="id3" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="16">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="0" xml:id="id4" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="0" />
+                                        <note tab.course="2" tab.fret="2" />
+                                        <note tab.course="3" tab.fret="3" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id3" />
+                            <fing playingHand="right" playingFinger="1" startid="#id4" />
+                        </measure>
+                        <measure n="4">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="2" />
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="2" />
+                                        <note tab.course="2" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym tab.line="3" />
+                                        <note tab.course="1" tab.fret="4" xml:id="id5" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="5" />
+                                        <note tab.course="2" tab.fret="2" />
+                                        <note tab.course="3" tab.fret="0" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id5" />
+                        </measure>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/_tests/tab/tab-003.mei
+++ b/_tests/tab/tab-003.mei
@@ -1,0 +1,226 @@
+<?xml version="1.0" standalone="no"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title>Italian lute tablature example</title>
+            </titleStmt>
+            <pubStmt>
+                <respStmt>
+                    <persName role="encoder">Olja Janjuš</persName>
+                </respStmt>
+                <date isodate="2024-12-04" />
+            </pubStmt>
+            <notesStmt>
+                <annot>Lute tablature rendering</annot>
+            </notesStmt>
+            <sourceDesc>
+                <source>
+                    <bibl>
+                        <title>Recercar Sexto</title>
+                        <title type="main">Itabulatura de lauto</title>
+                        <composer>Giovanni Maria da Crema</composer>
+                        <arranger>Francesco da Milano</arranger>
+                        <date>1546</date>
+                        <locus>B1v-B2r</locus>
+                    </bibl>
+                </source>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <appInfo>
+                <application isodate="2022-09-26" version="1.4.5">
+                    <name>luteconv</name>
+                </application>
+            </appInfo>
+        </encodingDesc>
+        <workList>
+            <work>
+                <title>Recercar Sexto</title>
+                <composer>Giovanni Maria da Crema</composer>
+            </work>
+        </workList>
+    </meiHead>
+    <music>
+        <body>
+            <mdiv n="1">
+                <score>
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef n="1" lines="6" notationtype="tab.lute.italian">
+                                <tuning>
+                                    <course n="1" pname="g" oct="4" />
+                                    <course n="2" pname="d" oct="4" />
+                                    <course n="3" pname="a" oct="3" />
+                                    <course n="4" pname="f" oct="3" />
+                                    <course n="5" pname="c" oct="3" />
+                                    <course n="6" pname="g" oct="2" />
+                                </tuning>
+                            </staffDef>
+                        </staffGrp>
+                    </scoreDef>
+                    <section n="1">
+                        <measure n="19">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="4" tab.fret="2" />
+                                        <note tab.course="5" tab.fret="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure n="20">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <note tab.course="2" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="2" />
+                                        <note tab.course="5" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="3" tab.fret="0" xml:id="id15" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="0" />
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="6" tab.fret="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="5" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="5" tab.fret="3" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id15" />
+                        </measure>
+                        <measure n="21">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="2" tab.fret="0" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="2" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="4" tab.fret="2" />
+                                        <note tab.course="5" tab.fret="3" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure n="22">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="8">
+                                        <note tab.course="2" tab.fret="0" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="2" tab.fret="2" xml:id="id16" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="2" tab.fret="3" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="1" tab.fret="0" xml:id="id17" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="2" />
+                                        <note tab.course="2" tab.fret="3" />
+                                        <note tab.course="4" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="1" tab.fret="3" />
+                                        <note tab.course="3" tab.fret="1" />
+                                        <note tab.course="4" tab.fret="2" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id16" />
+                            <fing playingHand="right" playingFinger="1" startid="#id17" />
+                        </measure>
+                        <measure n="23" metcon="false">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <note tab.course="1" tab.fret="2" />
+                                        <note tab.course="3" tab.fret="3" />
+                                        <note tab.course="5" tab.fret="0" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="0" xml:id="id18" />
+                                    </tabGrp>
+                                    <tabGrp dur="8">
+                                        <note tab.course="3" tab.fret="1" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fing playingHand="right" playingFinger="1" startid="#id18" />
+                        </measure>
+                        <measure n="25">
+                            <staff n="1">
+                                <layer n="1">
+                                    <tabGrp dur="4">
+                                        <tabDurSym />
+                                        <note tab.course="1" tab.fret="0" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="4">
+                                        <note tab.course="2" tab.fret="4" />
+                                        <note tab.course="3" tab.fret="0" />
+                                        <note tab.course="5" tab.fret="2" />
+                                    </tabGrp>
+                                    <tabGrp dur="2" xml:id="id19">
+                                        <note tab.course="1" tab.fret="0" />
+                                        <note tab.course="2" tab.fret="0" />
+                                        <note tab.course="4" tab.fret="2" />
+                                        <note tab.course="6" tab.fret="0" />
+                                    </tabGrp>
+                                </layer>
+                            </staff>
+                            <fermata startid="#id19" />
+                        </measure>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>


### PR DESCRIPTION
As decided with @DILewis, @musicog and @reinierdevalk we add the selected examples for the rendering of the tablature.<br/>
The first example (tab-001.mei) is the encoding of the last system of the piece in *French lute tablature*. Please note that there are dots indicating the fingering and the cross for the extension of the note duration - they should appear within the tablature staff, underneath the glyph. The diagonal line in the staff should also be drawn from the bottom of the glyph with a `startid` to the bottom of the next glyph with an `endid`. The example only contains the `xml:id`s required for these special features. Here is the corresponding passage in the facsimile:
<img width="966" alt="tab-001" src="https://github.com/user-attachments/assets/fe4b278f-3da2-451b-a719-b9860a34829a">
<br/>
The second example (tab-002.mei) is the encoding of the first system of the piece in *German lute tablature*. There are no features like fingering or extension here, but the glyphs should be placed accordingly in the 'conceptual' lines, as described in the documentation in chapter [7.2.2 Vertical Organisation in German Lute Tablature](https://music-encoding.org/guidelines/dev/content/tablature.html#tablature-vertical-org) . However, these lines are not visible in the German lute tablature and therefore shouldn't be rendered like in other lute tablature types. Here is the corresponding passage in the facsimile:
<img width="796" alt="tab-002" src="https://github.com/user-attachments/assets/d7d15dcb-de01-42bb-8a5f-2f7227c3487a">
<br/>
The last example (tab-003.mei) is the encoding of the last system of the piece in *Italian lute tablature*. Here we have the same dots indicating the fingering that should appear within the tablature staff, underneath the glyph. The example only contains the `xml:id`s required for these special features. Here is the corresponding passage in the facsimile:
<img width="673" alt="tab-003" src="https://github.com/user-attachments/assets/e5d9a787-7541-47d5-a5c5-82d4cabe903d">
<br/>
Many thanks from the tablature IG and the team of E-LAUTE project!
