### PR TITLE
Simplify octave examples in test suite

### DIFF
--- a/_tests/octave/octave-001.mei
+++ b/_tests/octave/octave-001.mei
@@ -14,8 +14,7 @@
             <title>Verovio test suite</title>
          </seriesStmt>
          <notesStmt>
-            <annot>Verovio supports the "octave" element for octave shifts. For correct MIDI output, the "oct.ges" attribute needs to be
-					provided.</annot>
+            <annot>Verovio supports the "octave" element for octave shifts.</annot>
          </notesStmt>
       </fileDesc>
       <encodingDesc>
@@ -59,12 +58,12 @@
                   <measure n="3">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1" dur="2" oct.ges="6" oct="5" pname="e" />
+                           <note xml:id="n1" dur="2" oct="5" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="6" oct="5" pname="f" />
-                              <note dur="8" oct.ges="6" oct="5" pname="a" />
-                              <note dur="8" oct.ges="6" oct="5" pname="g" />
-                              <note dur="8" oct.ges="6" oct="5" pname="b" />
+                              <note dur="8" oct="5" pname="f" />
+                              <note dur="8" oct="5" pname="a" />
+                              <note dur="8" oct="5" pname="g" />
+                              <note dur="8" oct="5" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -73,7 +72,7 @@
                   <measure right="dbl" n="4">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2" dur="1" oct.ges="7" oct="6" pname="c" />
+                           <note xml:id="n2" dur="1" oct="6" pname="c" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/octave/octave-002.mei
+++ b/_tests/octave/octave-002.mei
@@ -46,12 +46,12 @@
                   <measure n="1">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1" dur="2" oct.ges="2" oct="3" pname="e" />
+                           <note xml:id="n1" dur="2" oct="3" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="2" oct="3" pname="f" />
-                              <note dur="8" oct.ges="2" oct="3" pname="a" />
-                              <note dur="8" oct.ges="2" oct="3" pname="g" />
-                              <note dur="8" oct.ges="2" oct="3" pname="b" />
+                              <note dur="8" oct="3" pname="f" />
+                              <note dur="8" oct="3" pname="a" />
+                              <note dur="8" oct="3" pname="g" />
+                              <note dur="8" oct="3" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -60,19 +60,19 @@
                   <measure right="dbl" n="2">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2" dur="1" oct.ges="3" oct="4" pname="c" />
+                           <note xml:id="n2" dur="1" oct="4" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="4">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n3" dur="2" oct.ges="2" oct="4" pname="e" />
+                           <note xml:id="n3" dur="2" oct="4" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="2" oct="4" pname="f" />
-                              <note dur="8" oct.ges="2" oct="4" pname="a" />
-                              <note dur="8" oct.ges="2" oct="4" pname="g" />
-                              <note dur="8" oct.ges="2" oct="4" pname="b" />
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="8" oct="4" pname="a" />
+                              <note dur="8" oct="4" pname="g" />
+                              <note dur="8" oct="4" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -81,7 +81,7 @@
                   <measure right="dbl" n="5">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="1" oct.ges="3" oct="5" pname="c" />
+                           <note dur="1" oct="5" pname="c" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/octave/octave-003.mei
+++ b/_tests/octave/octave-003.mei
@@ -38,12 +38,12 @@
                   <measure n="1">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1" dur="2" oct.ges="2" oct="3" pname="e" />
+                           <note xml:id="n1" dur="2" oct="3" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="2" oct="3" pname="f" />
-                              <note dur="8" oct.ges="2" oct="3" pname="a" />
-                              <note dur="8" oct.ges="2" oct="3" pname="g" />
-                              <note dur="8" oct.ges="2" oct="3" pname="b" />
+                              <note dur="8" oct="3" pname="f" />
+                              <note dur="8" oct="3" pname="a" />
+                              <note dur="8" oct="3" pname="g" />
+                              <note dur="8" oct="3" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -52,19 +52,19 @@
                   <measure right="dbl" n="2">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2" dur="1" oct.ges="3" oct="4" pname="c" />
+                           <note xml:id="n2" dur="1" oct="4" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="4">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n3" dur="2" oct.ges="4" oct="3" pname="e" />
+                           <note xml:id="n3" dur="2" oct="3" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="4" oct="3" pname="f" />
-                              <note dur="8" oct.ges="4" oct="3" pname="a" />
-                              <note dur="8" oct.ges="4" oct="3" pname="g" />
-                              <note dur="8" oct.ges="4" oct="3" pname="b" />
+                              <note dur="8" oct="3" pname="f" />
+                              <note dur="8" oct="3" pname="a" />
+                              <note dur="8" oct="3" pname="g" />
+                              <note dur="8" oct="3" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -73,7 +73,7 @@
                   <measure right="dbl" n="5">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="1" oct.ges="5" oct="4" pname="c" />
+                           <note dur="1" oct="4" pname="c" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/octave/octave-004.mei
+++ b/_tests/octave/octave-004.mei
@@ -45,12 +45,12 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1a" dur="2" oct.ges="6" oct="5" pname="e" />
+                           <note xml:id="n1a" dur="2" oct="5" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="6" oct="5" pname="f" />
-                              <note dur="8" oct.ges="6" oct="5" pname="a" />
-                              <note dur="8" oct.ges="6" oct="5" pname="g" />
-                              <note dur="8" oct.ges="6" oct="5" pname="b" />
+                              <note dur="8" oct="5" pname="f" />
+                              <note dur="8" oct="5" pname="a" />
+                              <note dur="8" oct="5" pname="g" />
+                              <note dur="8" oct="5" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -59,7 +59,7 @@
                   <measure right="dbl">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2a" dur="2" oct.ges="7" oct="6" pname="c" />
+                           <note xml:id="n2a" dur="2" oct="6" pname="c" />
                            <rest dur="2" />
                         </layer>
                      </staff>
@@ -69,12 +69,12 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1b" dur="2" oct.ges="6" oct="5" pname="e" />
+                           <note xml:id="n1b" dur="2" oct="5" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="6" oct="5" pname="f" />
-                              <note dur="8" oct.ges="6" oct="5" pname="a" />
-                              <note dur="8" oct.ges="6" oct="5" pname="g" />
-                              <note dur="8" oct.ges="6" oct="5" pname="b" />
+                              <note dur="8" oct="5" pname="f" />
+                              <note dur="8" oct="5" pname="a" />
+                              <note dur="8" oct="5" pname="g" />
+                              <note dur="8" oct="5" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -83,7 +83,7 @@
                   <measure right="dbl">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2b" dots="1" dur="2" oct.ges="7" oct="6" pname="c" />
+                           <note xml:id="n2b" dots="1" dur="2" oct="6" pname="c" />
                            <rest dur="4" />
                         </layer>
                      </staff>
@@ -93,12 +93,12 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1c" dur="2" oct.ges="6" oct="5" pname="e" />
+                           <note xml:id="n1c" dur="2" oct="5" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="6" oct="5" pname="f" />
-                              <note dur="8" oct.ges="6" oct="5" pname="a" />
-                              <note dur="8" oct.ges="6" oct="5" pname="g" />
-                              <note dur="8" oct.ges="6" oct="5" pname="b" />
+                              <note dur="8" oct="5" pname="f" />
+                              <note dur="8" oct="5" pname="a" />
+                              <note dur="8" oct="5" pname="g" />
+                              <note dur="8" oct="5" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -107,7 +107,7 @@
                   <measure right="dbl">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2c" dots="2" dur="2" oct.ges="7" oct="6" pname="c" />
+                           <note xml:id="n2c" dots="2" dur="2" oct="6" pname="c" />
                            <rest dur="8" />
                         </layer>
                      </staff>


### PR DESCRIPTION
This PR removes the `oct.ges` attributes in the octave examples. They are not needed anymore due to [the changes in Verovio](https://github.com/rism-digital/verovio/pull/3906).