### PR TITLE
update testfiles with Verovio to MEI 5.1

### DIFF
--- a/_tests/accid/accid-001.mei
+++ b/_tests/accid/accid-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-002.mei
+++ b/_tests/accid/accid-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-003.mei
+++ b/_tests/accid/accid-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-004.mei
+++ b/_tests/accid/accid-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-005.mei
+++ b/_tests/accid/accid-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-006.mei
+++ b/_tests/accid/accid-006.mei
@@ -1,100 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>Altered unisons</title>
-            </titleStmt>
-            <pubStmt>
-                <respStmt>
-                    <persName role="encoder">Klaus Rettinghaus</persName>
-                    <corpName role="funder">Enote GmbH</corpName>
-                </respStmt>
-                <date isodate="2020">2020</date>
-            </pubStmt>
-            <seriesStmt>
-                <title>Verovio test suite</title>
-            </seriesStmt>
-            <notesStmt>
-                <annot>The order of accidentals for a chord containing a sharp and a natural sign is ♯♮, since ♮♯ might appear to be a sharp cancelling a double-sharp sign.</annot>
-            </notesStmt>
-            <sourceDesc>
-                <source>
-                    <bibl>Behind Bars, p. 51, example 2</bibl>
-                </source>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application version="3.0.0" label="2">
-                    <name>Verovio</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv>
-                <score>
-                    <scoreDef>
-                        <staffGrp>
-                            <staffDef n="1" lines="5" />
-                        </staffGrp>
-                    </scoreDef>
-                    <section>
-                        <measure n="1">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord dur="2">
-                                        <note oct="4" pname="a">
-                                            <accid accid="n" />
-                                        </note>
-                                        <note oct="4" pname="a">
-                                            <accid accid="s" />
-                                        </note>
-                                    </chord>
-                                    <chord dur="32">
-                                        <note oct="6" pname="c">
-                                            <accid accid="f" />
-                                        </note>
-                                        <note oct="6" pname="c">
-                                            <accid accid="n" />
-                                        </note>
-                                    </chord>
-                                    <beam>
-                                        <chord dur="8">
-                                            <note oct="5" pname="e">
-                                                <accid accid="f" />
-                                            </note>
-                                            <note oct="5" pname="e">
-                                                <accid accid="n" />
-                                            </note>
-                                        </chord>
-                                        <chord dur="8">
-                                            <note oct="5" pname="d" />
-                                            <note oct="5" pname="f" />
-                                        </chord>
-                                        <chord dur="8">
-                                            <note oct="5" pname="e">
-                                                <accid accid="f" />
-                                            </note>
-                                            <note oct="5" pname="e">
-                                                <accid accid="n" />
-                                            </note>
-                                        </chord>
-                                        <chord dur="8">
-                                            <note oct="5" pname="d" />
-                                            <note oct="5" pname="f" />
-                                        </chord>
-                                    </beam>
-                                </layer>
-                            </staff>
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Altered unisons</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="encoder">Klaus Rettinghaus</persName>
+               <corpName role="funder">Enote GmbH</corpName>
+            </respStmt>
+            <date isodate="2020">2020</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>The order of accidentals for a chord containing a sharp and a natural sign is ♯♮, since ♮♯ might appear to be a sharp cancelling a double-sharp sign.</annot>
+         </notesStmt>
+         <sourceDesc>
+            <source>
+               <bibl>Behind Bars, p. 51, example 2</bibl>
+            </source>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="3.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2">
+                              <note oct="4" pname="a">
+                                 <accid accid="n" />
+                              </note>
+                              <note oct="4" pname="a">
+                                 <accid accid="s" />
+                              </note>
+                           </chord>
+                           <chord dur="32">
+                              <note oct="6" pname="c">
+                                 <accid accid="f" />
+                              </note>
+                              <note oct="6" pname="c">
+                                 <accid accid="n" />
+                              </note>
+                           </chord>
+                           <beam>
+                              <chord dur="8">
+                                 <note oct="5" pname="e">
+                                    <accid accid="f" />
+                                 </note>
+                                 <note oct="5" pname="e">
+                                    <accid accid="n" />
+                                 </note>
+                              </chord>
+                              <chord dur="8">
+                                 <note oct="5" pname="d" />
+                                 <note oct="5" pname="f" />
+                              </chord>
+                              <chord dur="8">
+                                 <note oct="5" pname="e">
+                                    <accid accid="f" />
+                                 </note>
+                                 <note oct="5" pname="e">
+                                    <accid accid="n" />
+                                 </note>
+                              </chord>
+                              <chord dur="8">
+                                 <note oct="5" pname="d" />
+                                 <note oct="5" pname="f" />
+                              </chord>
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/accid/accid-007.mei
+++ b/_tests/accid/accid-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-008.mei
+++ b/_tests/accid/accid-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-009.mei
+++ b/_tests/accid/accid-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/accid/accid-010.mei
+++ b/_tests/accid/accid-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="encoder">Laurent Pugin</persName>
             </respStmt>
-            <date isodate="2022-10-04"/>
+            <date isodate="2022-10-04" />
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>

--- a/_tests/accid/accid-011.mei
+++ b/_tests/accid/accid-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/annot/annot-001.mei
+++ b/_tests/annot/annot-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -57,17 +57,13 @@
                            <annot>layer annotation</annot>
                         </layer>
                      </staff>
-                     <dir staff="1" tstamp="1.000000">
+                     <dir staff="1" tstamp="1">
                         <annot>annotation before text</annot>
-                        molto dolce
-                     </dir>
-                     <dir staff="1" tstamp="2.000000">
-                        più
+                        molto dolce</dir>
+                     <dir staff="1" tstamp="2">più
                         <annot>annotation between text</annot>
-                        exp.
-                     </dir>
-                     <dir staff="1" tstamp="3.000000">
-                        bouche fermée
+                        exp.</dir>
+                     <dir staff="1" tstamp="3">bouche fermée
                         <del>totalement</del>
                         <annot>annotation after text</annot>
                      </dir>

--- a/_tests/app/app-001.mei
+++ b/_tests/app/app-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef meter.count="4" meter.unit="4">
-                  <staffGrp symbol="bracket" n="1">
+                  <staffGrp n="1" symbol="bracket">
                      <staffDef label="Quinto" n="2" lines="5" clef.shape="G" clef.line="2" keysig="1f" />
                   </staffGrp>
                </scoreDef>
@@ -39,14 +39,14 @@
                      <lem />
                      <rdg label="original">
                         <scoreDef meter.sym="common">
-                           <staffGrp symbol="bracket" n="1">
+                           <staffGrp n="1" symbol="bracket">
                               <staffDef n="2" clef.shape="C" clef.line="1" />
                            </staffGrp>
                         </scoreDef>
                      </rdg>
                      <rdg source="#source1570">
                         <scoreDef>
-                           <staffGrp symbol="bracket" n="1">
+                           <staffGrp n="1" symbol="bracket">
                               <staffDef label="Sextus" n="2" />
                            </staffGrp>
                         </scoreDef>

--- a/_tests/app/app-002.mei
+++ b/_tests/app/app-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/app/app-003.mei
+++ b/_tests/app/app-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="bracket" n="1">
+                  <staffGrp n="1" symbol="bracket">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>

--- a/_tests/arpeg/arpeg-001.mei
+++ b/_tests/arpeg/arpeg-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffGrp symbol="brace" bar.thru="true">
+                     <staffGrp bar.thru="true" symbol="brace">
                         <label>Piano</label>
                         <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" keysig="3f" meter.count="3" meter.unit="4" />
                         <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.mode="major" keysig="3f" meter.count="3" meter.unit="4" />

--- a/_tests/arpeg/arpeg-002.mei
+++ b/_tests/arpeg/arpeg-002.mei
@@ -1,75 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>Arpeggio with accidentals</title>
-            </titleStmt>
-            <pubStmt>
-                <respStmt>
-                    <persName role="encoder">Klaus Rettinghaus</persName>
-                    <corpName role="funder">Enote GmbH</corpName>
-                </respStmt>
-                <date isodate="2020">2020</date>
-            </pubStmt>
-            <seriesStmt>
-                <title>Verovio test suite</title>
-            </seriesStmt>
-            <notesStmt>
-                <annot>Arpeggio signs should precede any accidentals, and must come after a bar line.</annot>
-            </notesStmt>
-            <sourceDesc>
-                <source>
-                    <bibl>Behind Bars, p. 131, example 2</bibl>
-                </source>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application version="2.0.0" label="2">
-                    <name>Verovio</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv>
-                <score>
-                    <scoreDef>
-                        <staffGrp>
-                            <staffGrp bar.thru="true">
-                                <staffDef n="1" lines="5" />
-                            </staffGrp>
-                        </staffGrp>
-                    </scoreDef>
-                    <section>
-                        <measure left="single">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord xml:id="ex_1015527891" dur="2">
-                                        <note oct="5" pname="f">
-                                            <accid accid="s" />
-                                        </note>
-                                        <note oct="5" pname="d">
-                                            <accid accid="s" />
-                                        </note>
-                                        <note oct="4" pname="a">
-                                            <accid accid="s" />
-                                        </note>
-                                        <note oct="4" pname="f">
-                                            <accid accid="s" />
-                                        </note>
-                                    </chord>
-                                </layer>
-                            </staff>
-                            <arpeg plist="#ex_1015527891" />
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Arpeggio with accidentals</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="encoder">Klaus Rettinghaus</persName>
+               <corpName role="funder">Enote GmbH</corpName>
+            </respStmt>
+            <date isodate="2020">2020</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Arpeggio signs should precede any accidentals, and must come after a bar line.</annot>
+         </notesStmt>
+         <sourceDesc>
+            <source>
+               <bibl>Behind Bars, p. 131, example 2</bibl>
+            </source>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffGrp bar.thru="true">
+                        <staffDef n="1" lines="5" />
+                     </staffGrp>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure left="single">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord xml:id="ex_1015527891" dur="2">
+                              <note oct="5" pname="f">
+                                 <accid accid="s" />
+                              </note>
+                              <note oct="5" pname="d">
+                                 <accid accid="s" />
+                              </note>
+                              <note oct="4" pname="a">
+                                 <accid accid="s" />
+                              </note>
+                              <note oct="4" pname="f">
+                                 <accid accid="s" />
+                              </note>
+                           </chord>
+                        </layer>
+                     </staff>
+                     <arpeg plist="#ex_1015527891" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/arpeg/arpeg-003.mei
+++ b/_tests/arpeg/arpeg-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -33,7 +33,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <labelAbbr />
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" meter.count="4" meter.unit="4" />

--- a/_tests/arpeg/arpeg-004.mei
+++ b/_tests/arpeg/arpeg-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/arpeg/arpeg-005.mei
+++ b/_tests/arpeg/arpeg-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,6 +39,7 @@
             <score>
                <scoreDef>
                   <staffGrp bar.thru="true">
+                     <grpSym symbol="brace" />
                      <staffDef n="1" lines="5" ppq="1">
                         <clef shape="G" line="2" />
                         <keySig sig="0" />

--- a/_tests/arpeg/arpeg-006.mei
+++ b/_tests/arpeg/arpeg-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -14,7 +14,7 @@
             </respStmt>
             <date isodate="2021-10-08">2021-10-08</date>
             <pubPlace>
-                <ref target="https://github.com/rism-digital/verovio/issues/1130"/>
+               <ref target="https://github.com/rism-digital/verovio/issues/1130" />
             </pubPlace>
          </pubStmt>
          <seriesStmt>

--- a/_tests/artic/artic-001.mei
+++ b/_tests/artic/artic-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-003.mei
+++ b/_tests/artic/artic-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -64,12 +64,12 @@
                            </beam>
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="1.000000" place="above" />
-                     <fermata staff="1" tstamp="1.500000" place="above" />
-                     <fermata staff="1" tstamp="2.000000" place="above" />
-                     <fermata staff="1" tstamp="2.500000" place="above" />
-                     <fermata staff="1" tstamp="3.000000" place="above" />
-                     <fermata staff="1" tstamp="3.500000" place="above" />
+                     <fermata staff="1" tstamp="1" place="above" />
+                     <fermata staff="1" tstamp="1.5" place="above" />
+                     <fermata staff="1" tstamp="2" place="above" />
+                     <fermata staff="1" tstamp="2.5" place="above" />
+                     <fermata staff="1" tstamp="3" place="above" />
+                     <fermata staff="1" tstamp="3.5" place="above" />
                   </measure>
                   <scoreDef meter.count="6" meter.unit="8" />
                   <measure right="end" n="2">
@@ -99,12 +99,12 @@
                            </beam>
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="1.000000" place="above" />
-                     <fermata staff="1" tstamp="2.000000" place="above" />
-                     <fermata staff="1" tstamp="3.000000" place="above" />
-                     <fermata staff="1" tstamp="4.000000" place="above" />
-                     <fermata staff="1" tstamp="5.000000" place="above" />
-                     <fermata staff="1" tstamp="6.000000" place="above" />
+                     <fermata staff="1" tstamp="1" place="above" />
+                     <fermata staff="1" tstamp="2" place="above" />
+                     <fermata staff="1" tstamp="3" place="above" />
+                     <fermata staff="1" tstamp="4" place="above" />
+                     <fermata staff="1" tstamp="5" place="above" />
+                     <fermata staff="1" tstamp="6" place="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/artic/artic-004.mei
+++ b/_tests/artic/artic-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef midi.bpm="240.000000">
+               <scoreDef midi.bpm="240">
                   <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="2s" meter.count="4" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="G" clef.line="2" keysig="2s" meter.count="4" meter.unit="4" />
@@ -159,7 +159,7 @@
                            <clef shape="G" line="2" />
                         </layer>
                      </staff>
-                     <dynam staff="2" tstamp="1.000000">sf</dynam>
+                     <dynam staff="2" tstamp="1">sf</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/artic/artic-005.mei
+++ b/_tests/artic/artic-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-006.mei
+++ b/_tests/artic/artic-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-007.mei
+++ b/_tests/artic/artic-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-008.mei
+++ b/_tests/artic/artic-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-009.mei
+++ b/_tests/artic/artic-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-010.mei
+++ b/_tests/artic/artic-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-011.mei
+++ b/_tests/artic/artic-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-012.mei
+++ b/_tests/artic/artic-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-013.mei
+++ b/_tests/artic/artic-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-014.mei
+++ b/_tests/artic/artic-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-015.mei
+++ b/_tests/artic/artic-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-016.mei
+++ b/_tests/artic/artic-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-017.mei
+++ b/_tests/artic/artic-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/artic/artic-018.mei
+++ b/_tests/artic/artic-018.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-001.mei
+++ b/_tests/barline/barline-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-002.mei
+++ b/_tests/barline/barline-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-003.mei
+++ b/_tests/barline/barline-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-004.mei
+++ b/_tests/barline/barline-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,13 +30,13 @@
                   <meterSig count="4" unit="4" />
                   <staffGrp>
                      <staffGrp bar.thru="true" symbol="bracketsq">
-                        <staffDef n="1" scale="75%" lines="5" clef.shape="G" clef.line="2" />
+                        <staffDef n="1" scale="75.00%" lines="5" clef.shape="G" clef.line="2" />
                         <staffGrp symbol="brace">
                            <staffDef n="2" lines="5" clef.shape="G" clef.line="2" />
                            <staffDef n="3" lines="5" clef.shape="G" clef.line="2" />
                         </staffGrp>
                      </staffGrp>
-                     <staffDef n="4" scale="50%" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef n="4" scale="50.00%" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/barline/barline-005.mei
+++ b/_tests/barline/barline-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-006.mei
+++ b/_tests/barline/barline-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,7 @@
                            <note dur="1" oct="3" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="between" staff="1 2" tstamp="5.000000">
+                     <dir place="between" staff="1 2" tstamp="5">
                         <rend halign="right" fontstyle="normal">fine</rend>
                      </dir>
                   </measure>
@@ -70,7 +70,7 @@
                            <note dur="1" oct="2" pname="b" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="between" staff="1 2" tstamp="5.000000">
+                     <dir place="between" staff="1 2" tstamp="5">
                         <rend halign="right" fontstyle="normal">fine</rend>
                      </dir>
                   </measure>
@@ -85,7 +85,7 @@
                            <note dur="1" oct="2" pname="a" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="between" staff="1 2" tstamp="5.000000">
+                     <dir place="between" staff="1 2" tstamp="5">
                         <rend halign="right" fontstyle="normal">fine</rend>
                      </dir>
                   </measure>

--- a/_tests/barline/barline-007.mei
+++ b/_tests/barline/barline-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-008.mei
+++ b/_tests/barline/barline-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-009.mei
+++ b/_tests/barline/barline-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/barline/barline-010.mei
+++ b/_tests/barline/barline-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -75,7 +75,7 @@
                               <multiRest num="4" />
                            </layer>
                         </staff>
-                        <reh staff="2" tstamp="0.000000">
+                        <reh staff="2" tstamp="0">
                            <rend halign="center" rend="box" fontsize="130.00%" fontstyle="normal" fontweight="bold">A</rend>
                         </reh>
                      </measure>
@@ -94,7 +94,7 @@
                               <multiRest num="16" />
                            </layer>
                         </staff>
-                        <tempo staff="2" tstamp="1.000000">Much much faster</tempo>
+                        <tempo staff="2" tstamp="1">Much much faster</tempo>
                      </measure>
                      <measure corresp="#none">
                         <staff n="2">

--- a/_tests/beam/beam-001.mei
+++ b/_tests/beam/beam-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-002.mei
+++ b/_tests/beam/beam-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-003.mei
+++ b/_tests/beam/beam-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-004.mei
+++ b/_tests/beam/beam-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-005.mei
+++ b/_tests/beam/beam-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-006.mei
+++ b/_tests/beam/beam-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-007.mei
+++ b/_tests/beam/beam-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-008.mei
+++ b/_tests/beam/beam-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-009.mei
+++ b/_tests/beam/beam-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-010.mei
+++ b/_tests/beam/beam-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-011.mei
+++ b/_tests/beam/beam-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-012.mei
+++ b/_tests/beam/beam-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-013.mei
+++ b/_tests/beam/beam-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-014.mei
+++ b/_tests/beam/beam-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-015.mei
+++ b/_tests/beam/beam-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-016.mei
+++ b/_tests/beam/beam-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-017.mei
+++ b/_tests/beam/beam-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-018.mei
+++ b/_tests/beam/beam-018.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-019.mei
+++ b/_tests/beam/beam-019.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-020.mei
+++ b/_tests/beam/beam-020.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-021.mei
+++ b/_tests/beam/beam-021.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-022.mei
+++ b/_tests/beam/beam-022.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-023.mei
+++ b/_tests/beam/beam-023.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-025.mei
+++ b/_tests/beam/beam-025.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-026.mei
+++ b/_tests/beam/beam-026.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,6 +36,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                         <staffDef n="1" lines="5">
                            <clef shape="G" line="2" />
@@ -45,7 +46,6 @@
                            <clef shape="F" line="4" />
                            <keySig sig="6f" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>

--- a/_tests/beam/beam-031.mei
+++ b/_tests/beam/beam-031.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-032.mei
+++ b/_tests/beam/beam-032.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-033.mei
+++ b/_tests/beam/beam-033.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-034.mei
+++ b/_tests/beam/beam-034.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-035.mei
+++ b/_tests/beam/beam-035.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-036.mei
+++ b/_tests/beam/beam-036.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-037.mei
+++ b/_tests/beam/beam-037.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-038.mei
+++ b/_tests/beam/beam-038.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-039.mei
+++ b/_tests/beam/beam-039.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-040.mei
+++ b/_tests/beam/beam-040.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-041.mei
+++ b/_tests/beam/beam-041.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-042.mei
+++ b/_tests/beam/beam-042.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-043.mei
+++ b/_tests/beam/beam-043.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-044.mei
+++ b/_tests/beam/beam-044.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-045.mei
+++ b/_tests/beam/beam-045.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -81,10 +81,10 @@
                            </chord>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegro, ma non troppo</tempo>
-                     <dynam staff="1" tstamp="1.000000">f</dynam>
-                     <pedal staff="2" tstamp="1.000000" dir="down" />
-                     <pedal staff="2" tstamp="3.500000" dir="up" />
+                     <tempo staff="1" tstamp="1">Allegro, ma non troppo</tempo>
+                     <dynam staff="1" tstamp="1">f</dynam>
+                     <pedal staff="2" tstamp="1" dir="down" />
+                     <pedal staff="2" tstamp="3.5" dir="up" />
                   </measure>
                   <measure n="2">
                      <staff n="1">

--- a/_tests/beam/beam-046.mei
+++ b/_tests/beam/beam-046.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-047.mei
+++ b/_tests/beam/beam-047.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-048.mei
+++ b/_tests/beam/beam-048.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-049.mei
+++ b/_tests/beam/beam-049.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -60,10 +60,10 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="0.500000">
+                     <dir place="above" staff="1" tstamp="0.5">
                         <rend halign="center" fontsize="125.00%" fontstyle="normal" fontweight="normal">VAR. XIII</rend>
                      </dir>
-                     <dynam place="below" staff="1" tstamp="0.750000" vgrp="1300">sempre f</dynam>
+                     <dynam place="below" staff="1" tstamp="0.75" vgrp="1300">sempre f</dynam>
                      <slur startid="#note-0000000396278772" endid="#note-0000001704964791" />
                   </measure>
                   <measure left="rptstart" n="327">

--- a/_tests/beam/beam-050.mei
+++ b/_tests/beam/beam-050.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -138,7 +138,7 @@
                            <clef shape="G" line="2" />
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1" tstamp="1.000000" vgrp="115">p</dynam>
+                     <dynam place="below" staff="1" tstamp="1" vgrp="115">p</dynam>
                      <tempo place="above" staff="1" startid="#note-0000001245833241" midi.bpm="160">non troppo presto</tempo>
                      <slur startid="#note-0000000252782235" endid="#note-0000000016801379" curvedir="above" />
                   </measure>

--- a/_tests/beam/beam-051.mei
+++ b/_tests/beam/beam-051.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-052.mei
+++ b/_tests/beam/beam-052.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-053.mei
+++ b/_tests/beam/beam-053.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-054.mei
+++ b/_tests/beam/beam-054.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-055.mei
+++ b/_tests/beam/beam-055.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-056.mei
+++ b/_tests/beam/beam-056.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-057.mei
+++ b/_tests/beam/beam-057.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-058.mei
+++ b/_tests/beam/beam-058.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-059.mei
+++ b/_tests/beam/beam-059.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-060.mei
+++ b/_tests/beam/beam-060.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-061.mei
+++ b/_tests/beam/beam-061.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-062.mei
+++ b/_tests/beam/beam-062.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-063.mei
+++ b/_tests/beam/beam-063.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-064.mei
+++ b/_tests/beam/beam-064.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-065.mei
+++ b/_tests/beam/beam-065.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beam/beam-066.mei
+++ b/_tests/beam/beam-066.mei
@@ -1,123 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
- <meiHead>
-  <fileDesc>
-   <titleStmt>
-    <title>Beam with space</title>
-   </titleStmt>
-   <pubStmt>
-    <respStmt>
-     <persName role="editor">Laurent Pugin</persName>
-    </respStmt>
-    <date isodate="2023-07-04"></date>
-    <pubPlace>
-     <ref target="https://github.com/rism-digital/verovio/issues/3439" />
-    </pubPlace>
-   </pubStmt>
-   <seriesStmt>
-    <title>Verovio test suite</title>
-   </seriesStmt>
-   <notesStmt>
-    <annot>Verovio supports space within beam</annot>
-   </notesStmt>
-  </fileDesc>
-  <encodingDesc>
-   <appInfo>
-    <application version="3.17.0" label="2">
-     <name>Verovio</name>
-    </application>
-   </appInfo>
-  </encodingDesc>
- </meiHead>
- <music>
-  <body>
-   <mdiv>
-    <score>
-     <scoreDef>
-      <staffGrp>
-       <staffDef n="1" lines="5">
-        <clef shape="G" line="2" />
-       </staffDef>
-      </staffGrp>
-     </scoreDef>
-     <section>
-      <measure n="1">
-       <staff n="1">
-        <layer n="1">
-         <beam place="above">    
-          <note dur="8" oct="4" pname="g" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="e" accid.ges="n" />
-          <space dur="8"/>
-         </beam>
-         <beam place="above">
-          <space dur="8"/>
-          <note dur="8" oct="4" pname="e" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="g" accid.ges="n" /> 
-         </beam>
-        </layer>
-       </staff>
-      </measure>
-      <measure n="2">
-       <staff n="1">
-        <layer n="1">
-         <beam place="below">    
-          <note dur="8" oct="4" pname="g" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="e" accid.ges="n" />
-          <space dur="8"/>
-         </beam>
-         <beam place="below">
-          <space dur="8"/>
-          <note dur="8" oct="4" pname="e" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="g" accid.ges="n" /> 
-         </beam>
-        </layer>
-       </staff>
-      </measure>
-      <measure n="3">
-       <staff n="1">
-        <layer n="1">
-         <beam place="above">    
-          <note dur="8" oct="4" pname="e" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="g" accid.ges="n" />
-          <space dur="8"/>
-         </beam>
-         <beam place="above">
-          <space dur="8"/>
-          <note dur="8" oct="4" pname="g" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="e" accid.ges="n" /> 
-         </beam>
-        </layer>
-       </staff>
-      </measure>
-      <measure n="4">
-       <staff n="1">
-        <layer n="1">
-         <beam place="below">    
-          <note dur="8" oct="4" pname="e" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="g" accid.ges="n" />
-          <space dur="8"/>
-         </beam>
-         <beam place="below">
-          <space dur="8"/>
-          <note dur="8" oct="4" pname="g" accid.ges="n" />
-          <note dur="8" oct="4" pname="f" accid.ges="n" />
-          <note dur="8" oct="4" pname="e" accid.ges="n" /> 
-         </beam>
-        </layer>
-       </staff>
-      </measure>
-     </section>
-    </score>
-   </mdiv>
-  </body>
- </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Beam with space</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="editor">Laurent Pugin</persName>
+            </respStmt>
+            <date isodate="2023-07-04" />
+            <pubPlace>
+               <ref target="https://github.com/rism-digital/verovio/issues/3439" />
+            </pubPlace>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports space within beam</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="3.17.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5">
+                        <clef shape="G" line="2" />
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam place="above">
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                              <space dur="8" />
+                           </beam>
+                           <beam place="above">
+                              <space dur="8" />
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam place="below">
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                              <space dur="8" />
+                           </beam>
+                           <beam place="below">
+                              <space dur="8" />
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam place="above">
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <space dur="8" />
+                           </beam>
+                           <beam place="above">
+                              <space dur="8" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam place="below">
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <space dur="8" />
+                           </beam>
+                           <beam place="below">
+                              <space dur="8" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
+                              <note dur="8" oct="4" pname="e" accid.ges="n" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/beamspan/beamspan-001.mei
+++ b/_tests/beamspan/beamspan-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -37,7 +37,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="120" key.mode="major" keysig="2f" meter.count="4" meter.unit="2" meter.sym="common">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                         <instrDef midi.channel="0" midi.instrnum="0" />
                      </staffDef>
@@ -58,15 +58,13 @@
                         </layer>
                      </staff>
                      <staff n="2">
-                        <layer n="1">
-                        </layer>
+                        <layer n="1" />
                      </staff>
-                     <beamSpan startid="#c01" endid="#c16" plist="#c01 #c02 #c03 #c04 #c05 #c13 #c14 #c15 #c16"/>
+                     <beamSpan plist="#c01 #c02 #c03 #c04 #c05 #c13 #c14 #c15 #c16" startid="#c01" endid="#c16" />
                   </measure>
                   <measure metcon="false" n="223">
                      <staff n="1">
-                        <layer n="1">
-                        </layer>
+                        <layer n="1" />
                      </staff>
                      <staff n="2">
                         <layer n="1">

--- a/_tests/beamspan/beamspan-002.mei
+++ b/_tests/beamspan/beamspan-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng"  schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng"  schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -48,14 +48,14 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="note-L3F1"  dur="8" oct="4" pname="b" stem.dir="up" />
-                           <note xml:id="note-L4F1"  dur="8" oct="4" pname="b" stem.dir="down" />
-                           <note xml:id="note-L5F1"  dur="8" oct="4" pname="b" stem.dir="up" />
-                           <note xml:id="note-L6F1"  dur="8" oct="4" pname="b" stem.dir="down" />
-                           <note xml:id="note-L8F1"  dur="8" oct="4" pname="b" stem.dir="up" />
-                           <note xml:id="note-L9F1"  dur="8" oct="4" pname="b" stem.dir="down" />
-                           <note xml:id="note-L10F1"  dur="8" oct="4" pname="b" stem.dir="up" />
-                           <note xml:id="note-L11F1"  dur="8" oct="4" pname="b" stem.dir="down" />
+                           <note xml:id="note-L3F1" dur="8" oct="4" pname="b" stem.dir="up" />
+                           <note xml:id="note-L4F1" dur="8" oct="4" pname="b" stem.dir="down" />
+                           <note xml:id="note-L5F1" dur="8" oct="4" pname="b" stem.dir="up" />
+                           <note xml:id="note-L6F1" dur="8" oct="4" pname="b" stem.dir="down" />
+                           <note xml:id="note-L8F1" dur="8" oct="4" pname="b" stem.dir="up" />
+                           <note xml:id="note-L9F1" dur="8" oct="4" pname="b" stem.dir="down" />
+                           <note xml:id="note-L10F1" dur="8" oct="4" pname="b" stem.dir="up" />
+                           <note xml:id="note-L11F1" dur="8" oct="4" pname="b" stem.dir="down" />
                         </layer>
                      </staff>
                      <beamSpan plist="#note-L3F1 #note-L5F1" startid="#note-L3F1" endid="#note-L5F1" />

--- a/_tests/beamspan/beamspan-003.mei
+++ b/_tests/beamspan/beamspan-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/beamspan/beamspan-004.mei
+++ b/_tests/beamspan/beamspan-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -50,7 +50,7 @@
                   </staffGrp>
                </scoreDef>
                <section>
-                  <pb/>
+                  <pb />
                   <measure>
                      <staff n="1">
                         <layer n="1">
@@ -84,11 +84,11 @@
                            </tuplet>
                         </layer>
                      </staff>
-                     <tie type="hanging-initial" staff="1" tstamp="0.000000" endid="#note-L5F2" />
+                     <tie type="hanging-initial" staff="1" tstamp="0" endid="#note-L5F2" />
                      <slur staff="2" startid="#note-L6F1" endid="#note-L31F1" />
                      <beamSpan plist="#note-L31F1 #note-L30F1 #note-L29F1 #note-L28F1 #note-L27F1 #note-L26F1 #note-L25F1 #note-L24F1 #note-L22F1 #note-L21F1 #note-L20F1 #note-L19F1 #note-L17F1 #note-L16F1 #note-L15F1 #note-L14F1 #note-L13F1 #note-L12F1 #note-L11F1 #note-L10F1 #note-L9F1 #note-L7F1 #note-L6F1" startid="#note-L6F1" endid="#note-L31F1" />
                   </measure>
-                  <sb/>
+                  <sb />
                   <measure n="2">
                      <staff n="1">
                         <layer n="1">
@@ -126,7 +126,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <sb/>
+                  <sb />
                   <measure n="3">
                      <staff n="1">
                         <layer n="1">

--- a/_tests/beamspan/beamspan-005.mei
+++ b/_tests/beamspan/beamspan-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,13 +36,13 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <staffDef n="1" lines="5">
                            <clef shape="G" line="2" />
                         </staffDef>
                         <staffDef n="2" lines="5">
                            <clef shape="G" line="2" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>

--- a/_tests/bracketspan/bracketspan-001.mei
+++ b/_tests/bracketspan/bracketspan-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -52,10 +52,10 @@
                      </staff>
                      <bracketSpan staff="1" startid="#n01" endid="#n02" func="ligature" />
                      <bracketSpan staff="1" startid="#n03" endid="#n04" func="ligature" />
-                     <bracketSpan staff="1" startid="#n05" endid="#n06" func="ligature" lwidth="0.750000vu" />
+                     <bracketSpan staff="1" startid="#n05" endid="#n06" func="ligature" lwidth="0.7500vu" />
                      <bracketSpan staff="1" startid="#n07" endid="#n08" func="ligature" lform="dotted" />
                      <bracketSpan staff="1" startid="#n09" endid="#n10" func="ligature" lform="solid" />
-                     <bracketSpan staff="1" tstamp="1.000000" tstamp2="0m+41.0000" func="ligature" lform="dashed" />
+                     <bracketSpan staff="1" tstamp="1" tstamp2="0m+41" func="ligature" lform="dashed" />
                   </measure>
                </section>
             </score>

--- a/_tests/breath/breath-001.mei
+++ b/_tests/breath/breath-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,7 +39,7 @@
                            <note dur="4" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <breath tstamp="1.800000" />
+                     <breath tstamp="1.8" />
                   </measure>
                </section>
             </score>

--- a/_tests/btrem/btrem-001.mei
+++ b/_tests/btrem/btrem-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/btrem/btrem-002.mei
+++ b/_tests/btrem/btrem-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/btrem/btrem-003.mei
+++ b/_tests/btrem/btrem-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/btrem/btrem-004.mei
+++ b/_tests/btrem/btrem-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/btrem/btrem-005.mei
+++ b/_tests/btrem/btrem-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/btrem/btrem-006.mei
+++ b/_tests/btrem/btrem-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/caesura/caesura-001.mei
+++ b/_tests/caesura/caesura-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -51,8 +51,8 @@
                            <note dur="2" oct="4" pname="e" accid.ges="n" />
                         </layer>
                      </staff>
-                     <caesura staff="1" tstamp="1.900000" />
-                     <caesura tstamp="4.000000" glyph.name="caesuraCurved" />
+                     <caesura staff="1" tstamp="1.9" />
+                     <caesura tstamp="4" glyph.name="caesuraCurved" />
                   </measure>
                   <measure right="dbl">
                      <staff n="1">

--- a/_tests/choice/choice-001.mei
+++ b/_tests/choice/choice-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -57,7 +57,7 @@
                            </choice>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">
+                     <tempo staff="1" tstamp="1">
                         <choice>
                            <sic>Alegro</sic>
                            <corr cert="medium">Allegro</corr>

--- a/_tests/chord/chord-001.mei
+++ b/_tests/chord/chord-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/chord/chord-002.mei
+++ b/_tests/chord/chord-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -43,13 +43,13 @@
                            <note dur="2" oct="4" pname="f" />
                         </layer>
                      </staff>
-                     <harm tstamp="1.000000">
+                     <harm tstamp="1">
                         <rend halign="right">Right</rend>
                      </harm>
-                     <harm tstamp="3.000000">
+                     <harm tstamp="3">
                         <rend halign="center">Cent.</rend>
                      </harm>
-                     <harm tstamp="5.000000">
+                     <harm tstamp="5">
                         <rend halign="left">Left</rend>
                      </harm>
                   </measure>

--- a/_tests/chord/chord-003.mei
+++ b/_tests/chord/chord-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/chord/chord-004.mei
+++ b/_tests/chord/chord-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/chord/chord-005.mei
+++ b/_tests/chord/chord-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.sym="common" keysig="0" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.sym="common" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/chord/chord-006.mei
+++ b/_tests/chord/chord-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/chord/chord-007.mei
+++ b/_tests/chord/chord-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -51,7 +51,7 @@
                      </staffDef>
                   </staffGrp>
                </scoreDef>
-               <section xml:id="sl2tg8f">
+               <section>
                   <measure right="invis">
                      <staff n="1">
                         <layer n="1">
@@ -111,7 +111,7 @@
                      </staff>
                   </measure>
                </section>
-               <section xml:id="s1b8d9p" restart="true">
+               <section restart="true">
                   <measure right="invis">
                      <staff n="1">
                         <layer n="1">
@@ -130,7 +130,7 @@
                      </staff>
                   </measure>
                </section>
-               <section xml:id="s2egcme" restart="true">
+               <section restart="true">
                   <measure right="invis">
                      <staff n="1">
                         <layer n="1">
@@ -159,7 +159,7 @@
                      </staff>
                   </measure>
                </section>
-               <section xml:id="vj348rg" restart="true">
+               <section restart="true">
                   <measure>
                      <staff n="1">
                         <layer n="1">
@@ -189,7 +189,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <measure metcon="false" right="invis">
+                  <measure right="invis" metcon="false">
                      <staff n="1">
                         <layer n="1">
                            <beam>

--- a/_tests/chord/chord-008.mei
+++ b/_tests/chord/chord-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-CMN.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/chord/chord-009.mei
+++ b/_tests/chord/chord-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -37,7 +37,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.sym="common" keysig="0" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.sym="common" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/chord/chord-010.mei
+++ b/_tests/chord/chord-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -46,15 +46,15 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <chord dur="4" cluster="chromatic" dots="1">
+                           <chord dots="1" dur="4" cluster="chromatic">
                               <note oct="4" pname="f" />
                               <note oct="4" pname="g" />
                            </chord>
-                           <chord dur="4" cluster="chromatic" dots="1">
+                           <chord dots="1" dur="4" cluster="chromatic">
                               <note oct="4" pname="f" />
                               <note oct="4" pname="a" />
                            </chord>
-                           <chord dur="4" cluster="chromatic" dots="1">
+                           <chord dots="1" dur="4" cluster="chromatic">
                               <note oct="4" pname="f" />
                               <note oct="4" pname="b" />
                            </chord>
@@ -64,15 +64,15 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <chord dur="4" cluster="chromatic" dots="1">
+                           <chord dots="1" dur="4" cluster="chromatic">
                               <note oct="4" pname="f" />
                               <note oct="5" pname="c" />
                            </chord>
-                           <chord dur="4" cluster="chromatic" dots="1">
+                           <chord dots="1" dur="4" cluster="chromatic">
                               <note oct="4" pname="f" />
                               <note oct="5" pname="d" />
                            </chord>
-                           <chord dur="4" cluster="chromatic" dots="1">
+                           <chord dots="1" dur="4" cluster="chromatic">
                               <note oct="4" pname="f" />
                               <note oct="5" pname="e" />
                            </chord>

--- a/_tests/clef/clef-001.mei
+++ b/_tests/clef/clef-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -66,7 +66,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1" tstamp="1.000000">fz</dynam>
+                     <dynam place="below" staff="1" tstamp="1">fz</dynam>
                   </measure>
                   <measure n="6">
                      <staff n="1">

--- a/_tests/clef/clef-002.mei
+++ b/_tests/clef/clef-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/clef/clef-003.mei
+++ b/_tests/clef/clef-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -40,12 +40,12 @@
                   <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
-                        <keySig pname="a" mode="major" sig="3s" />
+                        <keySig mode="major" sig="3s" pname="a" />
                         <meterSig count="3" unit="8" />
                      </staffDef>
                      <staffDef n="2" lines="5">
                         <clef shape="F" line="4" />
-                        <keySig pname="a" mode="major" sig="3s" />
+                        <keySig mode="major" sig="3s" pname="a" />
                         <meterSig count="3" unit="8" />
                      </staffDef>
                   </staffGrp>
@@ -74,7 +74,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <dynam place="between" staff="1 2" tstamp="1.000000">mf</dynam>
+                     <dynam place="between" staff="1 2" tstamp="1">mf</dynam>
                      <slur staff="1" startid="#note-L9F2" endid="#note-L22F2" />
                   </measure>
                   <measure n="16">

--- a/_tests/clef/clef-004.mei
+++ b/_tests/clef/clef-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -93,7 +93,7 @@
                         </layer>
                      </staff>
                      <turn staff="1" startid="#note-L9F2" accidlower="s" form="upper" />
-                     <dir place="between" staff="1 2" tstamp="1.000000">dolce</dir>
+                     <dir place="between" staff="1 2" tstamp="1">dolce</dir>
                      <turn staff="1" startid="#note-L13F2" form="upper" />
                      <turn staff="1" startid="#note-L17F2" form="upper" />
                      <turn staff="1" startid="#note-L21F2" form="upper" />
@@ -145,7 +145,7 @@
                         </layer>
                      </staff>
                      <turn staff="1" startid="#note-L27F2" accidlower="s" form="upper" />
-                     <dir place="between" staff="1 2" tstamp="1.000000">dolce</dir>
+                     <dir place="between" staff="1 2" tstamp="1">dolce</dir>
                      <turn staff="1" startid="#note-L31F2" form="upper" />
                      <turn staff="1" startid="#note-L36F2" form="upper" />
                      <turn staff="1" startid="#note-L40F2" form="upper" />

--- a/_tests/clef/clef-005.mei
+++ b/_tests/clef/clef-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -62,8 +62,8 @@
                            <clef shape="G" line="2" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000" vgrp="100">p</dynam>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+5.0000" form="cres" vgrp="100" />
+                     <dynam staff="1" tstamp="1" vgrp="100">p</dynam>
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+5" form="cres" vgrp="100" />
                   </measure>
                   <measure n="1">
                      <staff n="1">
@@ -77,8 +77,8 @@
                            <note dur="1" oct="4" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000" vgrp="100">p</dynam>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+5.0000" form="cres" vgrp="100" />
+                     <dynam staff="1" tstamp="1" vgrp="100">p</dynam>
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+5" form="cres" vgrp="100" />
                   </measure>
                </section>
             </score>

--- a/_tests/clef/clef-006.mei
+++ b/_tests/clef/clef-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/color/color-001.mei
+++ b/_tests/color/color-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -53,7 +53,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <tempo tstamp="1.000000">
+                     <tempo tstamp="1">
                         <rend color="hsl(0,100%,50%)">A</rend>
                         <rend color="hsl(35,100%,50%)">n</rend>
                         <rend color="hsl(70,100%,50%)">d</rend>
@@ -64,8 +64,8 @@
                         <rend color="hsl(245,100%,50%)">n</rend>
                         <rend color="hsl(280,100%,50%)">o</rend>
                      </tempo>
-                     <tie startid="#d414233e2644" endid="#d414233e2665" color="hsl(240,85%,35%)" />
-                     <hairpin startid="#d414233e2598" endid="#d414233e2665" color="rgb(24,231,76)" form="cres" place="above" />
+                     <tie color="hsl(240,85%,35%)" startid="#d414233e2644" endid="#d414233e2665" />
+                     <hairpin color="rgb(24,231,76)" startid="#d414233e2598" endid="#d414233e2665" form="cres" place="above" />
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -75,7 +75,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <fermata tstamp="1.000000" color="rgb(60,120,240)" place="above" />
+                     <fermata color="rgb(60,120,240)" tstamp="1" place="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/color/color-002.mei
+++ b/_tests/color/color-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/color/color-003.mei
+++ b/_tests/color/color-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/color/color-004.mei
+++ b/_tests/color/color-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/cross-staff/cross-staff-001.mei
+++ b/_tests/cross-staff/cross-staff-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -29,7 +29,7 @@
             <score>
                <scoreDef meter.count="4" meter.unit="4">
                   <staffGrp>
-                     <staffGrp symbol="brace" n="1">
+                     <staffGrp n="1" symbol="brace">
                         <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" />
                         <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.mode="major" />
                      </staffGrp>
@@ -131,9 +131,9 @@
                            <space dur="4" />
                         </layer>
                      </staff>
-                     <fermata place="above" staff="1" startid="#chord-0000001000950771"/>
-                     <fermata place="above" staff="1" startid="#chord-0000000683148902"/>
-                     <fermata place="above" staff="1" startid="#chord-0000001958371069"/>
+                     <fermata staff="1" startid="#chord-0000001000950771" place="above" />
+                     <fermata staff="1" startid="#chord-0000000683148902" place="above" />
+                     <fermata staff="1" startid="#chord-0000001958371069" place="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/cross-staff/cross-staff-002.mei
+++ b/_tests/cross-staff/cross-staff-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1f" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="1f" />
                   </staffGrp>

--- a/_tests/cross-staff/cross-staff-003.mei
+++ b/_tests/cross-staff/cross-staff-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1f" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="1f" />
                   </staffGrp>

--- a/_tests/cross-staff/cross-staff-004.mei
+++ b/_tests/cross-staff/cross-staff-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="180">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="3f" meter.count="4" meter.unit="4" meter.sym="common" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="3f" meter.count="4" meter.unit="4" meter.sym="common" />
                   </staffGrp>

--- a/_tests/cross-staff/cross-staff-005.mei
+++ b/_tests/cross-staff/cross-staff-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="182">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="4f" meter.count="3" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="4f" meter.count="3" meter.unit="4" />
                   </staffGrp>
@@ -48,9 +48,9 @@
                            <note dur="2" oct="2" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Vivace</tempo>
-                     <dynam staff="1" tstamp="1.000000">pp</dynam>
-                     <dir place="below" staff="1" tstamp="1.000000">sotto voce</dir>
+                     <tempo staff="1" tstamp="1">Vivace</tempo>
+                     <dynam staff="1" tstamp="1">pp</dynam>
+                     <dir place="below" staff="1" tstamp="1">sotto voce</dir>
                      <tie startid="#note-L21F2" endid="#note-L25F2" />
                      <slur staff="1" startid="#note-L21F2" endid="#note-L35F2" />
                   </measure>
@@ -155,7 +155,7 @@
                            <note dur="4" oct="2" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="below" staff="1" tstamp="1.000000">smorz.</dir>
+                     <dir place="below" staff="1" tstamp="1">smorz.</dir>
                      <slur staff="2" startid="#note-L47F1" endid="#note-L49F1" />
                   </measure>
                </section>

--- a/_tests/cross-staff/cross-staff-006.mei
+++ b/_tests/cross-staff/cross-staff-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/cross-staff/cross-staff-007.mei
+++ b/_tests/cross-staff/cross-staff-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
                         <meterSig count="6" unit="8" />

--- a/_tests/cross-staff/cross-staff-008.mei
+++ b/_tests/cross-staff/cross-staff-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffGrp symbol="brace" bar.thru="true">
+                     <staffGrp bar.thru="true" symbol="brace">
                         <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="1" meter.unit="4" />
                         <staffDef n="2" lines="5" clef.shape="F" clef.line="4" meter.count="1" meter.unit="4" />
                      </staffGrp>

--- a/_tests/cross-staff/cross-staff-009.mei
+++ b/_tests/cross-staff/cross-staff-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffGrp symbol="brace" bar.thru="true">
+                     <staffGrp bar.thru="true" symbol="brace">
                         <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                         <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                      </staffGrp>
@@ -52,7 +52,9 @@
                            <mSpace />
                         </layer>
                      </staff>
-                     <dir staff="1" place="above" tstamp="1.0"><rend fontsize="xx-small">place="above"</rend></dir>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend fontsize="xx-small">place="above"</rend>
+                     </dir>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -68,8 +70,10 @@
                            <mSpace />
                         </layer>
                      </staff>
-                     <dir staff="2" place="below" tstamp="1.0"><rend fontsize="xx-small">place="mixed"</rend></dir>
-                  </measure>             
+                     <dir place="below" staff="2" tstamp="1">
+                        <rend fontsize="xx-small">place="mixed"</rend>
+                     </dir>
+                  </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
@@ -84,7 +88,9 @@
                            <mSpace />
                         </layer>
                      </staff>
-                     <dir staff="1" place="above" tstamp="1.0"><rend fontsize="xx-small">stem up / up</rend></dir>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend fontsize="xx-small">stem up / up</rend>
+                     </dir>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -100,7 +106,9 @@
                            <mSpace />
                         </layer>
                      </staff>
-                     <dir staff="2" place="below" tstamp="1.0"><rend fontsize="xx-small">stem down / up</rend></dir>
+                     <dir place="below" staff="2" tstamp="1">
+                        <rend fontsize="xx-small">stem down / up</rend>
+                     </dir>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -116,7 +124,9 @@
                            <mSpace />
                         </layer>
                      </staff>
-                     <dir staff="1" place="above" tstamp="1.0"><rend fontsize="xx-small">stem default / up</rend></dir>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend fontsize="xx-small">stem default / up</rend>
+                     </dir>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -132,7 +142,9 @@
                            <mSpace />
                         </layer>
                      </staff>
-                     <dir staff="2" place="below" tstamp="1.0"><rend fontsize="xx-small">default</rend></dir>
+                     <dir place="below" staff="2" tstamp="1">
+                        <rend fontsize="xx-small">default</rend>
+                     </dir>
                   </measure>
                </section>
             </score>

--- a/_tests/cross-staff/cross-staff-010.mei
+++ b/_tests/cross-staff/cross-staff-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -14,8 +14,8 @@
          <pubStmt>
             <date>2020-11-29</date>
             <pubPlace>
-                <ref target="https://github.com/rism-digital/verovio/issues/1607"/>
-            </pubPlace>        
+               <ref target="https://github.com/rism-digital/verovio/issues/1607" />
+            </pubPlace>
          </pubStmt>
          <notesStmt>
             <annot>Cross-staff content and control event placement</annot>
@@ -34,14 +34,14 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="54">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
-                        <keySig accid="s" pname="c" mode="minor" sig="4s" />
+                        <keySig accid="s" mode="minor" sig="4s" pname="c" />
                      </staffDef>
                      <staffDef n="2" lines="5">
                         <clef shape="F" line="4" />
-                        <keySig accid="s" pname="c" mode="minor" sig="4s" />
+                        <keySig accid="s" mode="minor" sig="4s" pname="c" />
                      </staffDef>
                   </staffGrp>
                </scoreDef>
@@ -93,9 +93,9 @@
                            </chord>
                         </layer>
                      </staff>
-                     <hairpin type="endbar03" staff="1" tstamp="2.000000" tstamp2="0m+2.9700" form="cres" vgrp="100" />
-                     <dynam staff="1" tstamp="3.333333" vgrp="100">f</dynam>
-                     <hairpin type="endbar03" staff="1" tstamp="4.000000" tstamp2="0m+4.8033" form="dim" vgrp="100" />
+                     <hairpin type="endbar03" staff="1" tstamp="2" tstamp2="0m+2.97" form="cres" vgrp="100" />
+                     <dynam staff="1" tstamp="3.3333" vgrp="100">f</dynam>
+                     <hairpin type="endbar03" staff="1" tstamp="4" tstamp2="0m+4.8033" form="dim" vgrp="100" />
                      <slur staff="2" startid="#note-L13F1" endid="#note-L19F1" curvedir="below" />
                   </measure>
                </section>

--- a/_tests/cross-staff/cross-staff-011.mei
+++ b/_tests/cross-staff/cross-staff-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -14,8 +14,8 @@
          <pubStmt>
             <date>2020-11-29</date>
             <pubPlace>
-                <ref target="https://github.com/rism-digital/verovio/issues/1799"/>
-            </pubPlace>        
+               <ref target="https://github.com/rism-digital/verovio/issues/1799" />
+            </pubPlace>
          </pubStmt>
          <notesStmt>
             <annot>Cross-staff content and text control event placement</annot>
@@ -34,7 +34,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
                      </staffDef>
@@ -66,7 +66,7 @@
                            <note dur="4" oct="2" pname="e" stem.dir="down" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="2" tstamp="1.000000">
+                     <dir place="above" staff="2" tstamp="1">
                         <rend fontstyle="normal">some text</rend>
                      </dir>
                   </measure>
@@ -92,7 +92,7 @@
                            <note dur="4" oct="2" pname="e" stem.dir="down" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="2" tstamp="1.000000">
+                     <dir place="above" staff="2" tstamp="1">
                         <rend fontstyle="normal">some text</rend>
                      </dir>
                   </measure>

--- a/_tests/cross-staff/cross-staff-012.mei
+++ b/_tests/cross-staff/cross-staff-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
          <mdiv>
             <score>
                <scoreDef key.mode="major" key.pname="c" keysig="0" meter.count="2" meter.unit="4">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>

--- a/_tests/cross-staff/cross-staff-013.mei
+++ b/_tests/cross-staff/cross-staff-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
                      </staffDef>
@@ -60,7 +60,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegro</tempo>
+                     <tempo staff="1" tstamp="1">Allegro</tempo>
                      <slur staff="1" startid="#note-L5F1" endid="#note-L8F1" curvedir="above" />
                   </measure>
                </section>

--- a/_tests/cross-staff/cross-staff-014.mei
+++ b/_tests/cross-staff/cross-staff-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="3f" meter.count="2" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="3f" meter.count="2" meter.unit="4" />
                   </staffGrp>

--- a/_tests/cross-staff/cross-staff-015.mei
+++ b/_tests/cross-staff/cross-staff-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
          <mdiv n="1">
             <score>
                <scoreDef key.mode="major" key.pname="c" keysig="0" meter.count="2" meter.unit="4">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>

--- a/_tests/cross-staff/cross-staff-016.mei
+++ b/_tests/cross-staff/cross-staff-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
                         <meterSig count="3" unit="8" />

--- a/_tests/cross-staff/cross-staff-017.mei
+++ b/_tests/cross-staff/cross-staff-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -119,7 +119,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="dodgerblue" fontstyle="normal">automatic</rend>
                      </dir>
                   </measure>
@@ -160,7 +160,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="dodgerblue" fontstyle="normal">expected</rend>
                      </dir>
                   </measure>

--- a/_tests/cross-staff/cross-staff-018.mei
+++ b/_tests/cross-staff/cross-staff-018.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -65,8 +65,8 @@
                            </beam>
                         </layer>
                      </staff>
-                     <slur staff="1" startid="#note-L5F2" endid="#note-L8F2" color="limegreen" />
-                     <slur staff="2" startid="#note-L5F1" endid="#note-L8F1" color="blue" />
+                     <slur color="limegreen" staff="1" startid="#note-L5F2" endid="#note-L8F2" />
+                     <slur color="blue" staff="2" startid="#note-L5F1" endid="#note-L8F1" />
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -89,11 +89,11 @@
                            </beam>
                         </layer>
                      </staff>
-                     <slur staff="1" startid="#note-L11F2" endid="#note-L14F2" color="limegreen" />
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <slur color="limegreen" staff="1" startid="#note-L11F2" endid="#note-L14F2" />
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="dodgerblue" fontstyle="normal">automatic</rend>
                      </dir>
-                     <slur staff="1" startid="#note-L11F1" endid="#note-L14F1" color="blue" />
+                     <slur color="blue" staff="1" startid="#note-L11F1" endid="#note-L14F1" />
                   </measure>
                   <measure>
                      <staff n="1">
@@ -116,11 +116,11 @@
                            </beam>
                         </layer>
                      </staff>
-                     <slur staff="2" startid="#note-L17F2" endid="#note-L20F2" color="limegreen" curvedir="above" />
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <slur color="limegreen" staff="2" startid="#note-L17F2" endid="#note-L20F2" curvedir="above" />
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="dodgerblue" fontstyle="normal">expected</rend>
                      </dir>
-                     <slur staff="1" startid="#note-L17F1" endid="#note-L20F1" color="blue" curvedir="below" />
+                     <slur color="blue" staff="1" startid="#note-L17F1" endid="#note-L20F1" curvedir="below" />
                   </measure>
                </section>
             </score>

--- a/_tests/cross-staff/cross-staff-019.mei
+++ b/_tests/cross-staff/cross-staff-019.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -73,8 +73,8 @@
                      </staff>
                      <dynam place="between" staff="1 2" startid="#note_4038">f</dynam>
                      <slur staff="1" startid="#note_4002" endid="#note_4026" />
-                     <slur staff="1" startid="#note_4038" endid="#note_4050" color="blue" />
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <slur color="blue" staff="1" startid="#note_4038" endid="#note_4050" />
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="blue" fontstyle="normal">automatic<lb />(layers)</rend>
                      </dir>
                   </measure>
@@ -111,8 +111,8 @@
                      <dynam place="between" staff="1 2" startid="#note_4194a">f</dynam>
                      <slur staff="1" startid="#note_4152a" endid="#note_4164a" curvedir="above" />
                      <slur staff="1" startid="#note_4164a" endid="#note_4176a" curvedir="above" />
-                     <slur staff="1" startid="#note_4194a" endid="#note_4206a" color="green" />
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <slur color="green" staff="1" startid="#note_4194a" endid="#note_4206a" />
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="green" fontstyle="normal">automatic<lb />(cross-staff)</rend>
                      </dir>
                   </measure>
@@ -155,8 +155,8 @@
                      <dynam place="between" staff="1 2" startid="#note_4194b">f</dynam>
                      <slur staff="1" startid="#note_4152b" endid="#note_4164b" curvedir="above" />
                      <slur staff="1" startid="#note_4164b" endid="#note_4176b" curvedir="above" />
-                     <slur staff="1" startid="#note_4194b" endid="#note_4206b" color="green" curvedir="above" />
-                     <dir place="below" staff="2" tstamp="1.000000">
+                     <slur color="green" staff="1" startid="#note_4194b" endid="#note_4206b" curvedir="above" />
+                     <dir place="below" staff="2" tstamp="1">
                         <rend color="green" fontstyle="normal">expected<lb />(cross-staff)</rend>
                      </dir>
                   </measure>

--- a/_tests/cross-staff/cross-staff-020.mei
+++ b/_tests/cross-staff/cross-staff-020.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/cross-staff/cross-staff-021.mei
+++ b/_tests/cross-staff/cross-staff-021.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffGrp symbol="brace" bar.thru="true">
+                     <staffGrp bar.thru="true" symbol="brace">
                         <staffDef n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" keysig="0" meter.count="3" meter.unit="4" />
                         <staffDef n="2" lines="5" ppq="1" clef.shape="F" clef.line="4" keysig="0" meter.count="3" meter.unit="4" />
                      </staffGrp>

--- a/_tests/cross-staff/cross-staff-022.mei
+++ b/_tests/cross-staff/cross-staff-022.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -45,7 +45,7 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <space dur="4" dots="1" />
+                           <space dots="1" dur="4" />
                         </layer>
                      </staff>
                      <staff n="2">
@@ -57,29 +57,29 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dir staff="2" tstamp="2.200000">t</dir>
+                     <dir staff="2" tstamp="2.2">t</dir>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
                            <beam place="below">
-                              <note dur="8" staff="2" oct="3" pname="c" color="coral"/>
+                              <note dur="8" staff="2" oct="3" pname="c" color="coral" />
                               <note dur="8" oct="4" pname="c" />
-                              <note dur="8" staff="2" oct="3" pname="c" color="coral"/>
+                              <note dur="8" staff="2" oct="3" pname="c" color="coral" />
                            </beam>
                         </layer>
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <space dur="4" dots="1" />
+                           <space dots="1" dur="4" />
                         </layer>
                      </staff>
-                     <dir staff="2" tstamp="2.200000">t</dir>
+                     <dir staff="2" tstamp="2.2">t</dir>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <space dur="4" dots="1" />
+                           <space dots="1" dur="4" />
                         </layer>
                      </staff>
                      <staff n="2">
@@ -91,7 +91,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dir staff="1" tstamp="2.600000" place="above">t</dir>
+                     <dir place="above" staff="1" tstamp="2.6">t</dir>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -105,10 +105,10 @@
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <space dur="4" dots="1" />
+                           <space dots="1" dur="4" />
                         </layer>
                      </staff>
-                     <dir staff="1" tstamp="2.600000" place="above">t</dir>
+                     <dir place="above" staff="1" tstamp="2.6">t</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/cross-staff/cross-staff-023.mei
+++ b/_tests/cross-staff/cross-staff-023.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -37,6 +37,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <label>Piano</label>
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                         <staffDef n="1" lines="5" ppq="4">
@@ -49,7 +50,6 @@
                            <keySig sig="0" />
                            <meterSig count="4" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
@@ -106,7 +106,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <tempo place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="96">
+                     <tempo place="above" staff="1" tstamp="1" xml:lang="it" midi.bpm="96">
                         <rend fontfam="Times New Roman" fontweight="bold">Un peu retenu</rend>
                      </tempo>
                      <slur startid="#nknqyq" endid="#n67uxo" curvedir="above" />

--- a/_tests/cross-staff/cross-staff-024.mei
+++ b/_tests/cross-staff/cross-staff-024.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -37,6 +37,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <label>PIANO</label>
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                         <staffDef n="1" lines="5" ppq="4">
@@ -49,7 +50,6 @@
                            <keySig sig="0" />
                            <meterSig count="4" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
@@ -105,7 +105,7 @@
                            <note dur="1" oct="3" pname="a" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="2.000000" vgrp="241">
+                     <dir place="above" staff="1" tstamp="2" vgrp="241">
                         <rend fontfam="Times New Roman" fontstyle="italic">m.g. expressif</rend>
                      </dir>
                      <slur startid="#nbagov5" endid="#nd1je8i" curvedir="above" />

--- a/_tests/custos/custos-001.mei
+++ b/_tests/custos/custos-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/dir/dir-001.mei
+++ b/_tests/dir/dir-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>
@@ -71,9 +71,9 @@
                      </staff>
                      <slur startid="#d414233e2598" endid="#d414233e2617" />
                      <slur startid="#d414233e2644" endid="#d414233e2665" />
-                     <dir place="above" staff="1" tstamp="1.000000">a tempo</dir>
-                     <dir staff="1" tstamp="1.000000">sotto voce</dir>
-                     <dir staff="2" tstamp="1.000000">sempre legatissimo</dir>
+                     <dir place="above" staff="1" tstamp="1">a tempo</dir>
+                     <dir staff="1" tstamp="1">sotto voce</dir>
+                     <dir staff="2" tstamp="1">sempre legatissimo</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/dir/dir-002.mei
+++ b/_tests/dir/dir-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -41,7 +41,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">Allegro <rend>molto</rend>
+                     <dir place="above" staff="1" tstamp="1">Allegro <rend>molto</rend>
                      </dir>
                   </measure>
                   <measure n="2">
@@ -52,7 +52,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend xml:space="preserve">a         b       c</rend>
                      </dir>
                   </measure>
@@ -64,7 +64,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend xml:space="default">a b c</rend>
                      </dir>
                   </measure>

--- a/_tests/dir/dir-003.mei
+++ b/_tests/dir/dir-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef midi.bpm="140">
                   <staffGrp>
-                     <staffGrp label="Piano" symbol="brace" bar.thru="true">
+                     <staffGrp label="Piano" bar.thru="true" symbol="brace">
                         <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" keysig="3f" meter.count="4" meter.unit="4" meter.sym="common" />
                         <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.mode="major" keysig="3f" meter.count="4" meter.unit="4" meter.sym="common" />
                      </staffGrp>
@@ -91,11 +91,11 @@
                            </beam>
                         </layer>
                      </staff>
-                     <tempo place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="160">
+                     <tempo place="above" staff="1" tstamp="1" xml:lang="it" midi.bpm="160">
                         <rend fontweight="bold">Allegro con fuoco</rend>
                      </tempo>
-                     <dynam staff="1" tstamp="1.000000">f</dynam>
-                     <dir staff="2" tstamp="1.000000" xml:lang="it">
+                     <dynam staff="1" tstamp="1">f</dynam>
+                     <dir staff="2" tstamp="1" xml:lang="it">
                         <rend fontstyle="italic">legatissimo</rend>
                      </dir>
                   </measure>

--- a/_tests/dir/dir-004.mei
+++ b/_tests/dir/dir-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="192">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="3" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="0" meter.count="3" meter.unit="4" />
                   </staffGrp>
@@ -66,9 +66,9 @@
                            </chord>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegro non troppo</tempo>
-                     <dir place="above" staff="1" tstamp="1.000000">legato</dir>
-                     <dir place="above" staff="2" tstamp="1.000000">sotto voce</dir>
+                     <tempo staff="1" tstamp="1">Allegro non troppo</tempo>
+                     <dir place="above" staff="1" tstamp="1">legato</dir>
+                     <dir place="above" staff="2" tstamp="1">sotto voce</dir>
                      <slur staff="1" startid="#chord-L11F2" endid="#chord-L25F2" />
                      <slur staff="2" startid="#chord-L11F1" endid="#chord-L25F1" />
                   </measure>

--- a/_tests/dir/dir-005.mei
+++ b/_tests/dir/dir-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>
@@ -47,7 +47,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dir place="below" staff="2" tstamp="1.000000">legato</dir>
+                     <dir place="below" staff="2" tstamp="1">legato</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/dir/dir-006.mei
+++ b/_tests/dir/dir-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,10 +39,10 @@
                            <note dur="2" oct="5" pname="b" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">some long text</rend>
                      </dir>
-                     <fermata staff="1" tstamp="3.000000" place="above" />
+                     <fermata staff="1" tstamp="3" place="above" />
                   </measure>
                   <measure right="end">
                      <staff n="1">
@@ -50,8 +50,8 @@
                            <note dur="1" oct="3" pname="b" accid.ges="n" />
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="1.000000" place="below" />
-                     <dir place="below" staff="1" tstamp="1.000000">
+                     <fermata staff="1" tstamp="1" place="below" />
+                     <dir place="below" staff="1" tstamp="1">
                         <rend fontstyle="normal">text</rend>
                      </dir>
                   </measure>

--- a/_tests/dir/dir-007.mei
+++ b/_tests/dir/dir-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -70,11 +70,11 @@
                      </staff>
                      <slur startid="#d414233e2598" endid="#d414233e2617" />
                      <slur startid="#d414233e2644" endid="#d414233e2665" />
-                     <dir place="above" staff="1" tstamp="1.000000">a tempo</dir>
-                     <dir staff="1" tstamp="5.000000">
+                     <dir place="above" staff="1" tstamp="1">a tempo</dir>
+                     <dir staff="1" tstamp="5">
                         <rend halign="right">sotto<lb />voce</rend>
                      </dir>
-                     <dir staff="2" tstamp="1.000000">sempre <lb />legatissimo</dir>
+                     <dir staff="2" tstamp="1">sempre <lb />legatissimo</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/dir/dir-008.mei
+++ b/_tests/dir/dir-008.mei
@@ -1,92 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-	<meiHead>
-		<fileDesc>
-			<titleStmt>
-				<title>Box/circle enclosures for directives</title>
-			</titleStmt>
-			<pubStmt>
-				<date>2021-09-28</date>
-			</pubStmt>
-			<notesStmt>
-				<annot>Verovio can draw different types of enclosures around text directives.</annot>
-			</notesStmt>
-		</fileDesc>
-		<encodingDesc>
-			<appInfo>
-				<application version="2.0.0" label="2">
-					<name>Verovio</name>
-				</application>
-			</appInfo>
-		</encodingDesc>
-	</meiHead>
-	<music>
-		<body>
-			<mdiv>
-				<score>
-					<scoreDef midi.bpm="400">
-						<staffGrp>
-							<staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-						</staffGrp>
-					</scoreDef>
-					<section>
-						<measure n="0">
-							<staff n="1">
-								<layer n="1">
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-								</layer>
-							</staff>
-							<dir place="above" staff="1" tstamp="1.000000">
-								<rend fontstyle="normal" rend="box" fontweight="bold">A</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="2.000000">
-								<rend fontstyle="normal" rend="box" fontweight="bold">a</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="3.000000">
-								<rend fontstyle="normal" rend="box" fontweight="bold">J</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="4.000000">
-								<rend fontstyle="normal" rend="box" fontweight="bold">x</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="5.000000">
-								<rend fontstyle="normal" rend="box" fontweight="bold">22a</rend>
-							</dir>
-						</measure>
-						<measure n="1">
-							<staff n="1">
-								<layer n="1">
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-									<note dur="4" oct="4" pname="e" accid.ges="n" />
-								</layer>
-							</staff>
-							<dir place="above" staff="1" tstamp="1.000000">
-								<rend fontstyle="normal" rend="circle" fontweight="bold">K</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="2.000000">
-								<rend fontstyle="normal" rend="circle" fontweight="bold">a</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="3.000000">
-								<rend fontstyle="normal" rend="circle" fontweight="bold">J</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="4.000000">
-								<rend fontstyle="normal" rend="circle" fontweight="bold">x</rend>
-							</dir>
-							<dir place="above" staff="1" tstamp="5.000000">
-								<rend fontstyle="normal" rend="circle" fontweight="bold">22a</rend>
-							</dir>
-						</measure>						
-					</section>
-				</score>
-			</mdiv>
-		</body>
-	</music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Box/circle enclosures for directives</title>
+         </titleStmt>
+         <pubStmt>
+            <date>2021-09-28</date>
+         </pubStmt>
+         <notesStmt>
+            <annot>Verovio can draw different types of enclosures around text directives.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef midi.bpm="400">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="0">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                        </layer>
+                     </staff>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend rend="box" fontstyle="normal" fontweight="bold">A</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="2">
+                        <rend rend="box" fontstyle="normal" fontweight="bold">a</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="3">
+                        <rend rend="box" fontstyle="normal" fontweight="bold">J</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="4">
+                        <rend rend="box" fontstyle="normal" fontweight="bold">x</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="5">
+                        <rend rend="box" fontstyle="normal" fontweight="bold">22a</rend>
+                     </dir>
+                  </measure>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" accid.ges="n" />
+                        </layer>
+                     </staff>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend rend="circle" fontstyle="normal" fontweight="bold">K</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="2">
+                        <rend rend="circle" fontstyle="normal" fontweight="bold">a</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="3">
+                        <rend rend="circle" fontstyle="normal" fontweight="bold">J</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="4">
+                        <rend rend="circle" fontstyle="normal" fontweight="bold">x</rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="5">
+                        <rend rend="circle" fontstyle="normal" fontweight="bold">22a</rend>
+                     </dir>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/dir/dir-009.mei
+++ b/_tests/dir/dir-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -41,9 +41,15 @@
                            <note dur="4" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1"><rend fontfam="smufl" fontstyle="normal">&#xe045;</rend></dir>
-                     <dir place="above" staff="1" tstamp="2"><rend fontfam="smufl" fontstyle="normal">&#xe046;</rend></dir>
-                     <dir place="above" staff="1" tstamp="4"><rend fontfam="smufl" fontstyle="normal">&#xe047;</rend></dir>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend glyph.auth="smufl" fontstyle="normal"></rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="2">
+                        <rend glyph.auth="smufl" fontstyle="normal"></rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="4">
+                        <rend glyph.auth="smufl" fontstyle="normal"></rend>
+                     </dir>
                   </measure>
                   <measure right="end">
                      <staff n="1">
@@ -54,8 +60,12 @@
                            <note dur="4" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1"><rend fontfam="smufl" fontstyle="normal">&#xe048;</rend></dir>
-                     <dir place="above" staff="1" tstamp="3"><rend fontfam="smufl" fontstyle="normal">&#xe049;</rend></dir>
+                     <dir place="above" staff="1" tstamp="1">
+                        <rend glyph.auth="smufl" fontstyle="normal"></rend>
+                     </dir>
+                     <dir place="above" staff="1" tstamp="3">
+                        <rend glyph.auth="smufl" fontstyle="normal"></rend>
+                     </dir>
                   </measure>
                </section>
             </score>

--- a/_tests/dir/dir-010.mei
+++ b/_tests/dir/dir-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,7 +39,7 @@
                            <note dur="2" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">A (1 byte)</dir>
+                     <dir place="above" staff="1" tstamp="1">A (1 byte)</dir>
                   </measure>
                   <measure n="1">
                      <staff n="1">
@@ -48,7 +48,7 @@
                            <note dur="2" oct="4" pname="d" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">é (2 bytes)</dir>
+                     <dir place="above" staff="1" tstamp="1">é (2 bytes)</dir>
                   </measure>
                   <measure n="1">
                      <staff n="1">
@@ -57,7 +57,7 @@
                            <note dur="2" oct="4" pname="e" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">अ (3 bytes)</dir>
+                     <dir place="above" staff="1" tstamp="1">अ (3 bytes)</dir>
                   </measure>
                   <measure n="1">
                      <staff n="1">
@@ -66,7 +66,7 @@
                            <note dur="2" oct="4" pname="f" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">𠜎 (4 bytes)</dir>
+                     <dir place="above" staff="1" tstamp="1">𠜎 (4 bytes)</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/dot/dot-001.mei
+++ b/_tests/dot/dot-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/dot/dot-002.mei
+++ b/_tests/dot/dot-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,7 +36,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="88">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1f" meter.count="3" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="1f" meter.count="3" meter.unit="4" />
                   </staffGrp>
@@ -96,7 +96,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L12F2" endid="#note-L16F2" />
-                     <dynam staff="1" tstamp="1.000000">f</dynam>
+                     <dynam staff="1" tstamp="1">f</dynam>
                      <slur staff="1" startid="#note-L9F3" endid="#note-L11F3" curvedir="above" />
                   </measure>
                </section>

--- a/_tests/dot/dot-003.mei
+++ b/_tests/dot/dot-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/dot/dot-004.mei
+++ b/_tests/dot/dot-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -40,10 +40,10 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.line="2" clef.shape="G" clef.visible="false" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" clef.visible="false" />
                   </staffGrp>
                </scoreDef>
-               <section xml:id="example_03">
+               <section>
                   <measure>
                      <staff n="1">
                         <layer n="1">
@@ -57,7 +57,7 @@
                      </staff>
                   </measure>
                </section>
-               <section xml:id="example_04">
+               <section>
                   <measure>
                      <staff n="1">
                         <layer n="1">
@@ -72,7 +72,7 @@
                      </staff>
                   </measure>
                </section>
-               <section xml:id="example_05">
+               <section>
                   <measure>
                      <staff n="1">
                         <layer n="1">
@@ -98,7 +98,7 @@
                      </staff>
                   </measure>
                </section>
-               <section xml:id="example_06">
+               <section>
                   <measure>
                      <staff n="1">
                         <layer n="1">

--- a/_tests/dot/dot-005.mei
+++ b/_tests/dot/dot-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relax4g.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -14,8 +14,8 @@
             </respStmt>
             <date isodate="2021-04-14">2021-04-14</date>
             <pubPlace>
-                <ref target="https://github.com/rism-digital/verovio/pull/2248" />
-             </pubPlace>
+               <ref target="https://github.com/rism-digital/verovio/pull/2248" />
+            </pubPlace>
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>

--- a/_tests/dot/dot-006.mei
+++ b/_tests/dot/dot-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffDef n="1" lines="5">
-                        <clef  shape="G" line="2" visible="false"/>
+                        <clef shape="G" line="2" visible="false" />
                      </staffDef>
                   </staffGrp>
                </scoreDef>

--- a/_tests/dynam/dynam-001.mei
+++ b/_tests/dynam/dynam-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -44,10 +44,10 @@
                            <note dur="4" oct="4" pname="f" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">p</dynam>
-                     <dynam staff="1" tstamp="2.000000">f</dynam>
-                     <dynam staff="1" tstamp="3.000000">pf</dynam>
-                     <dynam staff="1" tstamp="4.000000">rfz</dynam>
+                     <dynam staff="1" tstamp="1">p</dynam>
+                     <dynam staff="1" tstamp="2">f</dynam>
+                     <dynam staff="1" tstamp="3">pf</dynam>
+                     <dynam staff="1" tstamp="4">rfz</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -58,10 +58,10 @@
                            <note dur="4" oct="5" pname="c" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">mf</dynam>
-                     <dynam staff="1" tstamp="2.000000">mp</dynam>
-                     <dynam staff="1" tstamp="3.000000">sfp</dynam>
-                     <dynam staff="1" tstamp="4.000000">sfz</dynam>
+                     <dynam staff="1" tstamp="1">mf</dynam>
+                     <dynam staff="1" tstamp="2">mp</dynam>
+                     <dynam staff="1" tstamp="3">sfp</dynam>
+                     <dynam staff="1" tstamp="4">sfz</dynam>
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -70,8 +70,8 @@
                            <note dur="2" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">ppppp</dynam>
-                     <dynam staff="1" tstamp="3.000000">fffff</dynam>
+                     <dynam staff="1" tstamp="1">ppppp</dynam>
+                     <dynam staff="1" tstamp="3">fffff</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/dynam/dynam-002.mei
+++ b/_tests/dynam/dynam-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -44,8 +44,8 @@
                            <note dur="4" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">pp</dynam>
-                     <dynam staff="1" tstamp="1.500000">cresc. molto</dynam>
+                     <dynam staff="1" tstamp="1">pp</dynam>
+                     <dynam staff="1" tstamp="1.5">cresc. molto</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -56,8 +56,8 @@
                            <note dur="4" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">ff</dynam>
-                     <dynam staff="1" tstamp="1.500000">dim. molto</dynam>
+                     <dynam staff="1" tstamp="1">ff</dynam>
+                     <dynam staff="1" tstamp="1.5">dim. molto</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/dynam/dynam-003.mei
+++ b/_tests/dynam/dynam-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -29,12 +29,12 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef key.mode="major" key.sig="1s" meter.count="4" meter.unit="4">
+               <scoreDef key.mode="major" keysig="1s" meter.count="4" meter.unit="4">
                   <staffGrp>
-                     <staffDef label="Voice" n="1" scale="75.00%" lines="5" clef.shape="G" clef.line="2" key.sig="1s" />
+                     <staffDef label="Voice" n="1" scale="75.00%" lines="5" clef.shape="G" clef.line="2" keysig="1s" />
                      <staffGrp label="Piano" symbol="brace">
-                        <staffDef n="2" lines="5" clef.shape="G" clef.line="2" key.sig="1s" />
-                        <staffDef n="3" lines="5" clef.shape="F" clef.line="4" key.sig="1s" />
+                        <staffDef n="2" lines="5" clef.shape="G" clef.line="2" keysig="1s" />
+                        <staffDef n="3" lines="5" clef.shape="F" clef.line="4" keysig="1s" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
@@ -75,8 +75,8 @@
                            <rest dur="4" />
                         </layer>
                      </staff>
-                     <dynam place="above" staff="1" tstamp="1.000000">pp</dynam>
-                     <dynam place="below" staff="2" tstamp="1.000000">pp</dynam>
+                     <dynam place="above" staff="1" tstamp="1">pp</dynam>
+                     <dynam place="below" staff="2" tstamp="1">pp</dynam>
                      <slur startid="#d1e284" endid="#d1e323" curvedir="below" />
                   </measure>
                   <measure n="1">
@@ -177,8 +177,8 @@
                            <rest dur="2" />
                         </layer>
                      </staff>
-                     <dynam place="above" staff="1" tstamp="3.500000">p</dynam>
-                     <dynam place="below" staff="2" tstamp="4.000000">p</dynam>
+                     <dynam place="above" staff="1" tstamp="3.5">p</dynam>
+                     <dynam place="below" staff="2" tstamp="4">p</dynam>
                      <slur staff="2" startid="#d1e540" endid="#d1e656" curvedir="below" />
                      <slur staff="2" startid="#d1e720" endid="#d1e760" curvedir="below" />
                   </measure>

--- a/_tests/dynam/dynam-004.mei
+++ b/_tests/dynam/dynam-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,8 +31,8 @@
             <score>
                <scoreDef midi.bpm="240">
                   <staffGrp bar.thru="true" symbol="brace">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s" meter.count="4" meter.unit="4" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="2s" meter.count="4" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="2s" meter.count="4" meter.unit="4" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="2s" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -62,7 +62,7 @@
                            <note xml:id="note-L9F2" dur="1" oct="1" pname="a" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dynam staff="2" tstamp="3.000000">sf</dynam>
+                     <dynam staff="2" tstamp="3">sf</dynam>
                      <tie startid="#note-L9F2" endid="#note-L19F1S1" />
                   </measure>
                   <measure n="228">

--- a/_tests/dynam/dynam-005.mei
+++ b/_tests/dynam/dynam-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -42,8 +42,8 @@
                            <note dur="2" oct="4" pname="e" />
                         </layer>
                      </staff>
-                     <dynam next="#dyn2" staff="1" tstamp="1.000000" extender="true" vgrp="1">cre</dynam>
-                     <dynam xml:id="dyn2" next="#dyn3" staff="1" tstamp="4.000000" extender="true" vgrp="1">sc</dynam>
+                     <dynam next="#dyn2" staff="1" tstamp="1" extender="true" vgrp="1">cre</dynam>
+                     <dynam xml:id="dyn2" next="#dyn3" staff="1" tstamp="4" extender="true" vgrp="1">sc</dynam>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -53,7 +53,7 @@
                            <note dur="8" oct="4" pname="b" stem.dir="up" artic="stacc" />
                         </layer>
                      </staff>
-                     <dynam xml:id="dyn3" next="#dyn4" staff="1" tstamp="2.000000" extender="true" vgrp="1">en</dynam>
+                     <dynam xml:id="dyn3" next="#dyn4" staff="1" tstamp="2" extender="true" vgrp="1">en</dynam>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -61,7 +61,7 @@
                            <note dur="1" oct="5" pname="c" />
                         </layer>
                      </staff>
-                     <dynam xml:id="dyn4" staff="1" tstamp="2.000000" extender="true" vgrp="1">do</dynam>
+                     <dynam xml:id="dyn4" staff="1" tstamp="2" extender="true" vgrp="1">do</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/dynam/dynam-006.mei
+++ b/_tests/dynam/dynam-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
             <score>
                <scoreDef>
                   <staffGrp bar.thru="true">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="3f" meter.count="4" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="3f" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -43,11 +43,11 @@
                            <note dur="4" oct="4" pname="f" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">ff e senza sordini ma non sfz</dynam>
-                     <dynam staff="1" tstamp="2.000000">
+                     <dynam staff="1" tstamp="1">ff e senza sordini ma non sfz</dynam>
+                     <dynam staff="1" tstamp="2">
                         <rend fontfam="Times">sempre pp e senza sordini</rend>
                      </dynam>
-                     <dynam staff="1" tstamp="3.000000">sempre fff rfz e poi<lb />poco <rend fontstyle="normal" fontweight="bold">a</rend> poco crescendo ma non ffff<lb />troppo</dynam>
+                     <dynam staff="1" tstamp="3">sempre fff rfz e poi<lb />poco <rend fontstyle="normal" fontweight="bold">a</rend> poco crescendo ma non ffff<lb />troppo</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/dynam/dynam-007.mei
+++ b/_tests/dynam/dynam-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,8 +31,8 @@
             <score>
                <scoreDef midi.bpm="240">
                   <staffGrp bar.thru="true" symbol="brace">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s" meter.count="4" meter.unit="4" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="2s" meter.count="4" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="2s" meter.count="4" meter.unit="4" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="2s" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -51,8 +51,8 @@
                            <note dur="2" oct="2" pname="g" />
                         </layer>
                      </staff>
-                     <dynam place="between" staff="1 2" tstamp="1.000000">p</dynam>
-                     <dynam place="between" staff="1 2" tstamp="3.000000">f</dynam>
+                     <dynam place="between" staff="1 2" tstamp="1">p</dynam>
+                     <dynam place="between" staff="1 2" tstamp="3">f</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -69,8 +69,8 @@
                            <note dur="2" oct="2" pname="g" />
                         </layer>
                      </staff>
-                     <dir place="between" staff="1 2" tstamp="1.000000">sempre<lb />molto<lb />legato</dir>
-                     <hairpin staff="1 2" tstamp="3.000000" tstamp2="0m+4.0000" form="dim" place="between" />
+                     <dir place="between" staff="1 2" tstamp="1">sempre<lb />molto<lb />legato</dir>
+                     <hairpin staff="1 2" tstamp="3" tstamp2="0m+4" form="dim" place="between" />
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -87,7 +87,7 @@
                            <note dur="2" oct="2" pname="g" />
                         </layer>
                      </staff>
-                     <tempo place="between" staff="1 2" tstamp="1.000000">All<rend rend="sup">o</rend>
+                     <tempo place="between" staff="1 2" tstamp="1">All<rend rend="sup">o</rend>
                      </tempo>
                   </measure>
                </section>

--- a/_tests/dynam/dynam-008.mei
+++ b/_tests/dynam/dynam-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,8 +31,8 @@
             <score>
                <scoreDef midi.bpm="240">
                   <staffGrp bar.thru="true" symbol="brace">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s" meter.count="4" meter.unit="4" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="2s" meter.count="4" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="2s" meter.count="4" meter.unit="4" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="2s" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -51,10 +51,10 @@
                            <note dur="2" oct="2" pname="g" />
                         </layer>
                      </staff>
-                     <dynam place="between" staff="1 2" tstamp="1.000000">p</dynam>
-                     <dynam place="between" staff="1 2" tstamp="2.000000">mp</dynam>
-                     <dynam place="between" staff="1 2" tstamp="3.000000">f</dynam>
-                     <dynam place="between" staff="1 2" tstamp="4.000000">mf</dynam>
+                     <dynam place="between" staff="1 2" tstamp="1">p</dynam>
+                     <dynam place="between" staff="1 2" tstamp="2">mp</dynam>
+                     <dynam place="between" staff="1 2" tstamp="3">f</dynam>
+                     <dynam place="between" staff="1 2" tstamp="4">mf</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -71,8 +71,8 @@
                            <note dur="2" oct="2" pname="g" />
                         </layer>
                      </staff>
-                     <dir place="between" staff="1 2" tstamp="1.000000">legato</dir>
-                     <hairpin staff="1 2" tstamp="3.000000" tstamp2="0m+4.0000" form="dim" place="between" />
+                     <dir place="between" staff="1 2" tstamp="1">legato</dir>
+                     <hairpin staff="1 2" tstamp="3" tstamp2="0m+4" form="dim" place="between" />
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -89,9 +89,9 @@
                            <note dur="2" oct="2" pname="g" />
                         </layer>
                      </staff>
-                     <tempo place="between" staff="1 2" tstamp="1.000000">All<rend rend="sup">o</rend>
+                     <tempo place="between" staff="1 2" tstamp="1">All<rend rend="sup">o</rend>
                      </tempo>
-                     <dir place="between" staff="1 2" tstamp="3.000000">cantabile</dir>
+                     <dir place="between" staff="1 2" tstamp="3">cantabile</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/dynam/dynam-009.mei
+++ b/_tests/dynam/dynam-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -45,10 +45,10 @@
                            <note dur="4" oct="4" pname="f" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">p</dynam>
-                     <dynam staff="1" tstamp="2.000000">f</dynam>
-                     <dynam staff="1" tstamp="3.000000">pf</dynam>
-                     <dynam staff="1" tstamp="4.000000">rfz</dynam>
+                     <dynam staff="1" tstamp="1">p</dynam>
+                     <dynam staff="1" tstamp="2">f</dynam>
+                     <dynam staff="1" tstamp="3">pf</dynam>
+                     <dynam staff="1" tstamp="4">rfz</dynam>
                   </measure>
                   <measure n="2" label="feature-example">
                      <staff n="1">
@@ -59,10 +59,10 @@
                            <note dur="4" oct="5" pname="c" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">mf</dynam>
-                     <dynam staff="1" tstamp="2.000000">mp</dynam>
-                     <dynam staff="1" tstamp="3.000000">sfp</dynam>
-                     <dynam staff="1" tstamp="4.000000">sfz</dynam>
+                     <dynam staff="1" tstamp="1">mf</dynam>
+                     <dynam staff="1" tstamp="2">mp</dynam>
+                     <dynam staff="1" tstamp="3">sfp</dynam>
+                     <dynam staff="1" tstamp="4">sfz</dynam>
                   </measure>
                   <measure n="3" label="feature-example">
                      <staff n="1">
@@ -71,8 +71,8 @@
                            <note dur="2" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">ppppp</dynam>
-                     <dynam staff="1" tstamp="3.000000">fffff</dynam>
+                     <dynam staff="1" tstamp="1">ppppp</dynam>
+                     <dynam staff="1" tstamp="3">fffff</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/editorial/editorial-001.mei
+++ b/_tests/editorial/editorial-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/editorial/editorial-002.mei
+++ b/_tests/editorial/editorial-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -42,7 +42,7 @@
                            <note dur="2" oct="6" pname="c" />
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegro <add>molto <unclear>vivace</unclear>
+                     <tempo staff="1" tstamp="1">Allegro <add>molto <unclear>vivace</unclear>
                         </add>
                      </tempo>
                   </measure>

--- a/_tests/ending/ending-001.mei
+++ b/_tests/ending/ending-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -29,10 +29,10 @@
             <score>
                <scoreDef midi.bpm="92">
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="2" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="2" meter.unit="4" />
                      <staffGrp symbol="brace">
-                        <staffDef n="2" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="2" meter.unit="4" />
-                        <staffDef n="3" lines="5" clef.shape="F" clef.line="4" key.sig="0" meter.count="2" meter.unit="4" />
+                        <staffDef n="2" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="2" meter.unit="4" />
+                        <staffDef n="3" lines="5" clef.shape="F" clef.line="4" keysig="0" meter.count="2" meter.unit="4" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>

--- a/_tests/ending/ending-002.mei
+++ b/_tests/ending/ending-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -29,7 +29,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="4" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -41,7 +41,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Minuet</tempo>
+                     <tempo staff="1" tstamp="1">Minuet</tempo>
                   </measure>
                   <ending n="1">
                      <measure n="2">
@@ -63,10 +63,10 @@
                               </note>
                            </layer>
                         </staff>
-                        <dir place="below" staff="1" tstamp="1.000000">fine</dir>
+                        <dir place="below" staff="1" tstamp="1">fine</dir>
                      </measure>
                   </ending>
-                  <scoreDef key.sig="1f" />
+                  <scoreDef keysig="1f" />
                   <measure left="rptstart" n="4">
                      <staff n="1">
                         <layer n="1">
@@ -75,7 +75,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Trio</tempo>
+                     <tempo staff="1" tstamp="1">Trio</tempo>
                   </measure>
                   <measure right="rptend" n="5">
                      <staff n="1">
@@ -85,7 +85,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <dir place="below" staff="1" tstamp="1.000000">minuet da capo</dir>
+                     <dir place="below" staff="1" tstamp="1">minuet da capo</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/ending/ending-003.mei
+++ b/_tests/ending/ending-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -40,7 +40,7 @@
                            <note dur="1" oct="4" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="2.000000" />
+                     <fermata staff="1" tstamp="2" />
                   </measure>
                   <measure left="rptstart" right="rptend" n="2">
                      <staff n="1">
@@ -49,7 +49,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <scoreDef key.sig="3f" />
+                  <scoreDef keysig="3f" />
                   <measure left="rptstart" n="3">
                      <staff n="1">
                         <layer n="1">

--- a/_tests/fermata/fermata-001.mei
+++ b/_tests/fermata/fermata-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/fermata/fermata-002.mei
+++ b/_tests/fermata/fermata-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/fermata/fermata-003.mei
+++ b/_tests/fermata/fermata-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/fermata/fermata-004.mei
+++ b/_tests/fermata/fermata-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -54,9 +54,9 @@
                            </note>
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="1.000000" place="above" />
+                     <fermata staff="1" tstamp="1" place="above" />
                      <slur staff="1" startid="#note-L2F1" endid="#note-L6F1" />
-                     <fermata staff="1" tstamp="3.000000" place="above" />
+                     <fermata staff="1" tstamp="3" place="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/fermata/fermata-005.mei
+++ b/_tests/fermata/fermata-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,8 +28,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4"
-                        meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/fermata/fermata-006.mei
+++ b/_tests/fermata/fermata-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/fermata/fermata-007.mei
+++ b/_tests/fermata/fermata-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -63,7 +63,7 @@
                            <note dur="4" loc="0" />
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="7.000000" place="above" />
+                     <fermata staff="1" tstamp="7" place="above" />
                   </measure>
                   <scoreDef>
                      <staffGrp>
@@ -101,7 +101,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="7.000000" place="above" />
+                     <fermata staff="1" tstamp="7" place="above" />
                   </measure>
                   <scoreDef>
                      <staffGrp>
@@ -125,7 +125,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="7.000000" place="above" />
+                     <fermata staff="1" tstamp="7" place="above" />
                   </measure>
                   <measure n="61">
                      <staff n="1">
@@ -145,7 +145,7 @@
                            <rest dur="4" />
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="7.000000" place="above" />
+                     <fermata staff="1" tstamp="7" place="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/figured-bass/figured-bass-001.mei
+++ b/_tests/figured-bass/figured-bass-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="3" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="0" meter.count="3" meter.unit="4" />
                   </staffGrp>
@@ -76,7 +76,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="1.000000">
+                     <harm place="below" staff="2" tstamp="1">
                         <fb>
                            <f>♯</f>
                         </fb>
@@ -109,12 +109,12 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L14F3" endid="#note-L17F3" />
-                     <harm place="below" staff="2" tstamp="1.000000">
+                     <harm place="below" staff="2" tstamp="1">
                         <fb>
                            <f>5</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.750000">
+                     <harm place="below" staff="2" tstamp="2.75">
                         <fb>
                            <f>6♮</f>
                         </fb>
@@ -182,7 +182,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="3.000000">
+                     <harm place="below" staff="2" tstamp="3">
                         <fb>
                            <f>6</f>
                         </fb>
@@ -218,12 +218,12 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L29F3" endid="#note-L30F3" />
-                     <harm place="below" staff="2" tstamp="2.000000">
+                     <harm place="below" staff="2" tstamp="2">
                         <fb>
                            <f>7</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="3.500000">
+                     <harm place="below" staff="2" tstamp="3.5">
                         <fb>
                            <f>6</f>
                         </fb>
@@ -247,7 +247,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="1.000000">
+                     <harm place="below" staff="2" tstamp="1">
                         <fb>
                            <f>♯</f>
                         </fb>
@@ -293,7 +293,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="1.000000">
+                     <harm place="below" staff="2" tstamp="1">
                         <fb>
                            <f>♯</f>
                         </fb>
@@ -326,12 +326,12 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L45F3" endid="#note-L48F3" />
-                     <harm place="below" staff="2" tstamp="1.000000">
+                     <harm place="below" staff="2" tstamp="1">
                         <fb>
                            <f>5</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.750000">
+                     <harm place="below" staff="2" tstamp="2.75">
                         <fb>
                            <f>6♮</f>
                         </fb>
@@ -405,7 +405,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="2.500000">
+                     <harm place="below" staff="2" tstamp="2.5">
                         <fb>
                            <f>6</f>
                         </fb>
@@ -435,19 +435,19 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="1.000000">
+                     <harm place="below" staff="2" tstamp="1">
                         <fb>
                            <f>7</f>
                            <f>5</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.000000">
+                     <harm place="below" staff="2" tstamp="2">
                         <fb>
                            <f>5</f>
                            <f>4</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.750000">
+                     <harm place="below" staff="2" tstamp="2.75">
                         <fb>
                            <f>3♯</f>
                         </fb>

--- a/_tests/figured-bass/figured-bass-002.mei
+++ b/_tests/figured-bass/figured-bass-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef meter.count="4" meter.unit="4" meter.sym="common">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>
@@ -49,25 +49,25 @@
                            <note dur="2" oct="3" pname="g" stem.dir="down" />
                         </layer>
                      </staff>
-                     <harm place="above" staff="2" tstamp="1.000000">
+                     <harm place="above" staff="2" tstamp="1">
                         <fb>
                            <f>♭</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.000000">
+                     <harm place="below" staff="2" tstamp="2">
                         <fb>
                            <f>6♭</f>
                            <f>4</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="3.000000">
+                     <harm place="below" staff="2" tstamp="3">
                         <fb>
                            <f>7</f>
                            <f>5</f>
                            <f>4</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="2" tstamp="4.000000">
+                     <harm place="below" staff="2" tstamp="4">
                         <fb>
                            <f>_</f>
                            <f>_</f>

--- a/_tests/figured-bass/figured-bass-003.mei
+++ b/_tests/figured-bass/figured-bass-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -56,31 +56,31 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm place="below" tstamp="1.000000">
+                     <harm place="below" tstamp="1">
                         <fb>
                            <f>6</f>
-                           <f tstamp="1.000000" tstamp2="0m+2.0000">4</f>
-                           <f tstamp="1.000000" tstamp2="0m+2.0000">3</f>
+                           <f tstamp="1" tstamp2="0m+2">4</f>
+                           <f tstamp="1" tstamp2="0m+2">3</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="2.000000">
+                     <harm place="below" tstamp="2">
                         <fb>
                            <f>♯6</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="3.000000">
+                     <harm place="below" tstamp="3">
                         <fb>
                            <f>6</f>
-                           <f tstamp="3.000000" tstamp2="0m+4.5000">4</f>
-                           <f tstamp="3.000000" tstamp2="0m+4.0000">3</f>
+                           <f tstamp="3" tstamp2="0m+4.5">4</f>
+                           <f tstamp="3" tstamp2="0m+4">3</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="4.000000">
+                     <harm place="below" tstamp="4">
                         <fb>
                            <f>6</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="4.500000">
+                     <harm place="below" tstamp="4.5">
                         <fb>
                            <f>♯3</f>
                         </fb>
@@ -107,31 +107,31 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm place="below" tstamp="1.000000">
+                     <harm place="below" tstamp="1">
                         <fb>
                            <f>6</f>
-                           <f tstamp="1.000000" tstamp2="0m+2.0000">4</f>
-                           <f tstamp="1.000000" tstamp2="0m+2.0000">3</f>
+                           <f tstamp="1" tstamp2="0m+2">4</f>
+                           <f tstamp="1" tstamp2="0m+2">3</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="2.000000">
+                     <harm place="below" tstamp="2">
                         <fb>
                            <f>♯6</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="3.000000">
+                     <harm place="below" tstamp="3">
                         <fb>
                            <f>♯6</f>
-                           <f tstamp="3.000000" tstamp2="0m+4.5000">4</f>
-                           <f tstamp="3.000000" tstamp2="0m+4.0000">3</f>
+                           <f tstamp="3" tstamp2="0m+4.5">4</f>
+                           <f tstamp="3" tstamp2="0m+4">3</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="4.000000">
+                     <harm place="below" tstamp="4">
                         <fb>
                            <f>6</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="4.500000">
+                     <harm place="below" tstamp="4.5">
                         <fb>
                            <f>♯3</f>
                         </fb>
@@ -154,31 +154,31 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm place="below" tstamp="1.000000">
+                     <harm place="below" tstamp="1">
                         <fb>
                            <f>6</f>
-                           <f tstamp="1.000000" tstamp2="0m+2.0000">4</f>
-                           <f tstamp="1.000000" tstamp2="0m+2.0000">3</f>
+                           <f tstamp="1" tstamp2="0m+2">4</f>
+                           <f tstamp="1" tstamp2="0m+2">3</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="2.000000">
+                     <harm place="below" tstamp="2">
                         <fb>
                            <f>♯6</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="3.000000">
+                     <harm place="below" tstamp="3">
                         <fb>
                            <f>♯6</f>
-                           <f tstamp="3.000000" tstamp2="0m+4.5000">4</f>
-                           <f tstamp="3.000000" tstamp2="0m+4.0000">3</f>
+                           <f tstamp="3" tstamp2="0m+4.5">4</f>
+                           <f tstamp="3" tstamp2="0m+4">3</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="4.000000">
+                     <harm place="below" tstamp="4">
                         <fb>
                            <f>6</f>
                         </fb>
                      </harm>
-                     <harm place="below" tstamp="4.500000">
+                     <harm place="below" tstamp="4.5">
                         <fb>
                            <f>♯3</f>
                         </fb>

--- a/_tests/figured-bass/figured-bass-004.mei
+++ b/_tests/figured-bass/figured-bass-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -54,22 +54,22 @@
                </scoreDef>
                <section>
                   <measure>
-                     <harm staff="3" tstamp="2.000000">
+                     <harm staff="3" tstamp="2">
                         <fb>
                            <f></f>
                         </fb>
                      </harm>
-                     <harm staff="2" tstamp="2.000000">
+                     <harm staff="2" tstamp="2">
                         <fb>
                            <f></f>
                         </fb>
                      </harm>
-                     <harm staff="3" tstamp="3.000000">
+                     <harm staff="3" tstamp="3">
                         <fb>
                            <f></f>
                         </fb>
                      </harm>
-                     <harm staff="2" tstamp="3.000000">
+                     <harm staff="2" tstamp="3">
                         <fb>
                            <f></f>
                         </fb>

--- a/_tests/figured-bass/figured-bass-005.mei
+++ b/_tests/figured-bass/figured-bass-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -53,8 +53,8 @@
                      </staff>
                      <harm staff="1" tstamp="1">
                         <fb>
-                           <f extender="true" tstamp="1" tstamp2="1m+5">6</f>
-                           <f extender="true" tstamp="1" tstamp2="1m+5">4</f>
+                           <f tstamp="1" tstamp2="1m+5" extender="true">6</f>
+                           <f tstamp="1" tstamp2="1m+5" extender="true">4</f>
                         </fb>
                      </harm>
                   </measure>

--- a/_tests/fing/fing-001.mei
+++ b/_tests/fing/fing-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/fing/fing-002.mei
+++ b/_tests/fing/fing-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -99,7 +99,7 @@
                      <tie startid="#note-m17-l2-1" endid="#note-m17-l2-4" curvedir="below" />
                      <tie startid="#note-m17-l2-2" endid="#note-m17-l1-1" curvedir="above" />
                      <tie startid="#note-m17-l2-3" endid="#note-m17-l2-5" curvedir="above" />
-                     <hairpin staff="2" tstamp="2.000000" tstamp2="0m+5.0000" form="cres" />
+                     <hairpin staff="2" tstamp="2" tstamp2="0m+5" form="cres" />
                      <fing place="below" staff="2" startid="#note-m17-l3-1">5</fing>
                      <fing place="below" staff="2" startid="#note-m17-l3-2">1</fing>
                      <fing place="below" staff="2" startid="#note-m17-l3-3">3</fing>
@@ -164,7 +164,7 @@
                      </staff>
                      <slur startid="#chord-m18-l2-1" endid="#chord-m18-l2-2" curvedir="above" />
                      <slur startid="#chord-m18-l2-1" endid="#chord-m18-l2-2" curvedir="below" />
-                     <hairpin staff="2" tstamp="1.000000" tstamp2="0m+5.0000" form="dim" />
+                     <hairpin staff="2" tstamp="1" tstamp2="0m+5" form="dim" />
                      <fing place="below" staff="2" startid="#note-m18-l3-1">1</fing>
                      <fing place="below" staff="2" startid="#note-m18-l3-2">4</fing>
                      <fing place="below" staff="2" startid="#note-m18-l3-3">1</fing>

--- a/_tests/ftrem/ftrem-001.mei
+++ b/_tests/ftrem/ftrem-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef key.sig="1f" meter.count="4" meter.unit="4">
+               <scoreDef keysig="1f" meter.count="4" meter.unit="4">
                   <staffGrp symbol="bracket">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="C" clef.line="3" />

--- a/_tests/ftrem/ftrem-002.mei
+++ b/_tests/ftrem/ftrem-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -57,8 +57,8 @@
                            </fTrem>
                         </layer>
                      </staff>
-                     <slur type="ftrem" staff="1" startid="#note-L10F1" endid="#note-L13F1" color="coral" curvedir="below" />
-                     <slur type="ftrem" staff="1" startid="#note-L6F1" endid="#note-L9F1" color="coral" />
+                     <slur color="coral" type="ftrem" staff="1" startid="#note-L10F1" endid="#note-L13F1" curvedir="below" />
+                     <slur color="coral" type="ftrem" staff="1" startid="#note-L6F1" endid="#note-L9F1" />
                   </measure>
                   <measure>
                      <staff n="1">

--- a/_tests/gliss/gliss01.mei
+++ b/_tests/gliss/gliss01.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gliss/gliss02.mei
+++ b/_tests/gliss/gliss02.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="C" clef.line="1" key.sig="4s" />
+                     <staffDef n="1" lines="5" clef.shape="C" clef.line="1" keysig="4s" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -53,12 +53,12 @@
                            </chord>
                         </layer>
                      </staff>
-                     <gliss startid="#note-0000000387804174" endid="#note-0000001641057499" color="purple" />
-                     <gliss startid="#note-0000000821839605" endid="#note-0000001592091470" color="orange" />
-                     <gliss startid="#note-0000000774533766" endid="#note-0000000184866789" color="blue" />
-                     <gliss startid="#note-0000001641057499" endid="#note-0000000115699169" color="cyan" />
-                     <gliss startid="#note-0000001592091470" endid="#note-0000001606207059" color="darkgreen" />
-                     <gliss startid="#note-0000000184866789" endid="#note-0000000115699169" color="violet" />
+                     <gliss color="purple" startid="#note-0000000387804174" endid="#note-0000001641057499" />
+                     <gliss color="orange" startid="#note-0000000821839605" endid="#note-0000001592091470" />
+                     <gliss color="blue" startid="#note-0000000774533766" endid="#note-0000000184866789" />
+                     <gliss color="cyan" startid="#note-0000001641057499" endid="#note-0000000115699169" />
+                     <gliss color="darkgreen" startid="#note-0000001592091470" endid="#note-0000001606207059" />
+                     <gliss color="violet" startid="#note-0000000184866789" endid="#note-0000000115699169" />
                   </measure>
                   <measure right="end" n="2">
                      <staff n="1">
@@ -75,9 +75,9 @@
                            </chord>
                         </layer>
                      </staff>
-                     <gliss startid="#note-0000000993369007" endid="#note-0000000230987856" color="chartreuse" />
-                     <gliss startid="#note-0000001606207059" endid="#note-0000000656887221" color="goldenrod" />
-                     <gliss startid="#note-0000000115699169" endid="#note-0000000656887221" color="hotpink" />
+                     <gliss color="chartreuse" startid="#note-0000000993369007" endid="#note-0000000230987856" />
+                     <gliss color="goldenrod" startid="#note-0000001606207059" endid="#note-0000000656887221" />
+                     <gliss color="hotpink" startid="#note-0000000115699169" endid="#note-0000000656887221" />
                   </measure>
                </section>
             </score>

--- a/_tests/gliss/gliss03.mei
+++ b/_tests/gliss/gliss03.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gliss/gliss04.mei
+++ b/_tests/gliss/gliss04.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" key.sig="0" meter.count="4" meter.unit="4">
+                     <staffDef n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" keysig="0" meter.count="4" meter.unit="4">
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />

--- a/_tests/gliss/gliss05.mei
+++ b/_tests/gliss/gliss05.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gliss/gliss06.mei
+++ b/_tests/gliss/gliss06.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -48,7 +48,7 @@
                            <note xml:id="note-0000001076743506" dur="2" oct="4" pname="e" />
                         </layer>
                      </staff>
-                     <gliss lform="wavy" staff="1" startid="#note-0000001664638115" endid="#note-0000001076743506" />
+                     <gliss staff="1" startid="#note-0000001664638115" endid="#note-0000001076743506" lform="wavy" />
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -61,7 +61,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <gliss lform="wavy" staff="1" startid="#note-0000001999368153" endid="#note-0000001881924406" />
+                     <gliss staff="1" startid="#note-0000001999368153" endid="#note-0000001881924406" lform="wavy" />
                   </measure>
                   <measure right="end" n="3">
                      <staff n="1">
@@ -71,8 +71,8 @@
                            <note xml:id="note-0000001990135686" dur="4" oct="4" pname="b" />
                         </layer>
                      </staff>
-                     <gliss lform="wavy" staff="1" startid="#note-0000001815811722" endid="#note-0000001676543830" />
-                     <gliss lform="wavy" staff="1" startid="#note-0000001676543830" endid="#note-0000001990135686" />
+                     <gliss staff="1" startid="#note-0000001815811722" endid="#note-0000001676543830" lform="wavy" />
+                     <gliss staff="1" startid="#note-0000001676543830" endid="#note-0000001990135686" lform="wavy" />
                   </measure>
                </section>
             </score>

--- a/_tests/gracenote/gracenote-001.mei
+++ b/_tests/gracenote/gracenote-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" key.sig="2s" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" keysig="2s" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/gracenote/gracenote-002.mei
+++ b/_tests/gracenote/gracenote-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-003.mei
+++ b/_tests/gracenote/gracenote-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-004.mei
+++ b/_tests/gracenote/gracenote-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="F" clef.line="4" />
                      <staffDef n="2" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="3" lines="5" clef.shape="F" clef.line="4" />

--- a/_tests/gracenote/gracenote-005.mei
+++ b/_tests/gracenote/gracenote-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -80,7 +80,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="3.000000" />
+                     <trill staff="1" tstamp="3" />
                   </measure>
                   <measure right="end">
                      <staff n="1">

--- a/_tests/gracenote/gracenote-006.mei
+++ b/_tests/gracenote/gracenote-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-007.mei
+++ b/_tests/gracenote/gracenote-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-008.mei
+++ b/_tests/gracenote/gracenote-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="3" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" meter.count="3" meter.unit="4" />
                   </staffGrp>

--- a/_tests/gracenote/gracenote-009.mei
+++ b/_tests/gracenote/gracenote-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,9 +27,9 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s" meter.count="2" meter.unit="2" meter.sym="cut" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="2s" meter.count="2" meter.unit="2" meter.sym="cut" />
+                  <staffGrp bar.thru="true" symbol="brace">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="2s" meter.count="2" meter.unit="2" meter.sym="cut" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="2s" meter.count="2" meter.unit="2" meter.sym="cut" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -118,7 +118,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L168F2" endid="#note-L169F2" />
-                     <dynam staff="1" tstamp="2.000000">f</dynam>
+                     <dynam staff="1" tstamp="2">f</dynam>
                      <tie startid="#note-L168F1S1" endid="#note-L169F1S1" />
                      <slur staff="2" startid="#chord-L168F1" endid="#chord-L169F1" curvedir="above" />
                      <slur staff="2" startid="#note-L172F1" endid="#note-L174F1" />

--- a/_tests/gracenote/gracenote-010.mei
+++ b/_tests/gracenote/gracenote-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,9 +27,9 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="0" />
+                  <staffGrp bar.thru="true" symbol="brace">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="0" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -69,7 +69,7 @@
                            <clef shape="G" line="2" />
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="2.500000" />
+                     <trill staff="1" tstamp="2.5" />
                   </measure>
                </section>
             </score>

--- a/_tests/gracenote/gracenote-011.mei
+++ b/_tests/gracenote/gracenote-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,9 +27,9 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="120">
-                  <staffGrp symbol="brace" bar.thru="true">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="4" meter.unit="4" meter.sym="common" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="0" meter.count="4" meter.unit="4" meter.sym="common" />
+                  <staffGrp bar.thru="true" symbol="brace">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="4" meter.unit="4" meter.sym="common" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="0" meter.count="4" meter.unit="4" meter.sym="common" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/gracenote/gracenote-012.mei
+++ b/_tests/gracenote/gracenote-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-013.mei
+++ b/_tests/gracenote/gracenote-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-014.mei
+++ b/_tests/gracenote/gracenote-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -35,7 +35,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                         <label />
                      </staffDef>

--- a/_tests/gracenote/gracenote-015.mei
+++ b/_tests/gracenote/gracenote-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,7 +34,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="400">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                         <label />
                      </staffDef>

--- a/_tests/gracenote/gracenote-016.mei
+++ b/_tests/gracenote/gracenote-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -33,10 +33,10 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef key.mode="major" key.pname="a" key.sig="3s" meter.count="3" meter.unit="4">
-                  <staffGrp symbol="brace" bar.thru="true">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="2s" />
+               <scoreDef key.mode="major" key.pname="a" keysig="3s" meter.count="3" meter.unit="4">
+                  <staffGrp bar.thru="true" symbol="brace">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="2s" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="2s" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/gracenote/gracenote-017.mei
+++ b/_tests/gracenote/gracenote-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -33,7 +33,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef optimize="false" key.mode="major" key.pname="e" key.sig="3f" meter.count="6" meter.unit="8">
+               <scoreDef optimize="false" key.mode="major" key.pname="e" keysig="3f" meter.count="6" meter.unit="8">
                   <staffGrp symbol="brace">
                      <staffDef label="Vl. I" n="6" lines="5" clef.shape="G" clef.line="2">
                         <label>Violino I</label>

--- a/_tests/gracenote/gracenote-018.mei
+++ b/_tests/gracenote/gracenote-018.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,7 @@
                            <note dur="8" oct="4" pname="g" grace="unacc" accid.ges="n" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+5.0000" form="dim" vgrp="100" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+5" form="dim" vgrp="100" />
                   </measure>
                </section>
             </score>

--- a/_tests/gracenote/gracenote-019.mei
+++ b/_tests/gracenote/gracenote-019.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-020.mei
+++ b/_tests/gracenote/gracenote-020.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-021.mei
+++ b/_tests/gracenote/gracenote-021.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-022.mei
+++ b/_tests/gracenote/gracenote-022.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -35,10 +35,10 @@
             <score>
                <scoreDef>
                   <staffGrp bar.thru="true" symbol="brace">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="5s">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="5s">
                         <label />
                      </staffDef>
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="5s" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="5s" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/gracenote/gracenote-023.mei
+++ b/_tests/gracenote/gracenote-023.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,6 +36,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <label>Piano</label>
                         <staffDef n="1" lines="5">
                            <clef shape="G" line="2" />
@@ -45,7 +46,6 @@
                            <clef shape="F" line="4" />
                            <keySig sig="5s" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>

--- a/_tests/gracenote/gracenote-024.mei
+++ b/_tests/gracenote/gracenote-024.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-025.mei
+++ b/_tests/gracenote/gracenote-025.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-026.mei
+++ b/_tests/gracenote/gracenote-026.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/gracenote/gracenote-027.mei
+++ b/_tests/gracenote/gracenote-027.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -68,10 +68,10 @@
                            </beam>
                         </layer>
                      </staff>
-                     <slur staff="1" startid="#note_6564a" endid="#note_6576a" color="orange" curvedir="below" />
-                     <slur staff="1" startid="#note_6564" endid="#note_6576" color="orange" curvedir="below" />
-                     <slur staff="1" startid="#note_6006" endid="#note_6018" color="orange" curvedir="below" />
-                     <slur staff="1" startid="#note_6006a" endid="#note_6018a" color="orange" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6564a" endid="#note_6576a" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6564" endid="#note_6576" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6006" endid="#note_6018" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6006a" endid="#note_6018a" curvedir="below" />
                   </measure>
                   <measure>
                      <staff n="1">
@@ -102,10 +102,10 @@
                            </beam>
                         </layer>
                      </staff>
-                     <slur staff="1" startid="#note_6564b" endid="#note_6576b" color="orange" curvedir="below" />
-                     <slur staff="1" startid="#note_6564ab" endid="#note_6576ab" color="orange" curvedir="below" />
-                     <slur staff="1" startid="#note_6006ab" endid="#note_6018ab" color="orange" curvedir="below" />
-                     <slur staff="1" startid="#note_6006b" endid="#note_6018b" color="orange" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6564b" endid="#note_6576b" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6564ab" endid="#note_6576ab" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6006ab" endid="#note_6018ab" curvedir="below" />
+                     <slur color="orange" staff="1" startid="#note_6006b" endid="#note_6018b" curvedir="below" />
                   </measure>
                </section>
             </score>

--- a/_tests/hairpin/hairpin-001.mei
+++ b/_tests/hairpin/hairpin-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef key.mode="major" key.sig="1s" meter.count="4" meter.unit="4">
+               <scoreDef key.mode="major" keysig="1s" meter.count="4" meter.unit="4">
                   <staffGrp>
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
@@ -40,7 +40,7 @@
                            <note dur="2" oct="4" pname="g" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="5m+3.0000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="5m+3" form="cres" />
                   </measure>
                   <measure n="2">
                      <staff n="1">

--- a/_tests/hairpin/hairpin-002.mei
+++ b/_tests/hairpin/hairpin-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -38,9 +38,9 @@
                   <measure n="5">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="d690095e1338" dur="4" oct="5" pname="f" tie="i" />
+                           <note xml:id="d690095e1338" dur="4" oct="5" pname="f" />
                            <beam>
-                              <note xml:id="d690095e1355" dur="8" oct="5" pname="f" tie="t" />
+                              <note xml:id="d690095e1355" dur="8" oct="5" pname="f" />
                               <note dur="16" oct="5" pname="g" />
                               <note dur="16" oct="5" pname="f" />
                            </beam>
@@ -52,7 +52,7 @@
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <note xml:id="d690095e1454" dots="1" dur="2" oct="4" pname="b" tie="i" />
+                           <note xml:id="d690095e1454" dots="1" dur="2" oct="4" pname="b" />
                         </layer>
                      </staff>
                      <staff n="3">
@@ -65,11 +65,13 @@
                            <note xml:id="d690095e1513" dots="1" dur="2" oct="3" pname="d" />
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1 2 3 4" tstamp="1.000000">p</dynam>
-                     <hairpin staff="1 2 3 4" tstamp="1.500000" tstamp2="1m+1.5000" form="cres" place="below" />
+                     <dynam place="below" staff="1 2 3 4" tstamp="1">p</dynam>
+                     <hairpin staff="1 2 3 4" tstamp="1.5" tstamp2="1m+1.5" form="cres" place="below" />
                      <slur startid="#d690095e1355" endid="#d690095e1411" curvedir="above" />
                      <slur startid="#d690095e1485" endid="#d690095e1620" curvedir="above" />
                      <slur startid="#d690095e1513" endid="#d690095e1651" curvedir="above" />
+                     <tie startid="#d690095e1338" endid="#d690095e1355" />
+                     <tie startid="#d690095e1454" endid="#d690095e1580" />
                   </measure>
                   <measure n="6">
                      <staff n="1">
@@ -80,7 +82,7 @@
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <note xml:id="d690095e1580" dur="2" oct="4" pname="b" tie="t" />
+                           <note xml:id="d690095e1580" dur="2" oct="4" pname="b" />
                            <note xml:id="d690095e1603" dur="4" oct="4" pname="g" />
                         </layer>
                      </staff>
@@ -94,7 +96,7 @@
                            <note xml:id="d690095e1651" dots="1" dur="2" oct="3" pname="e" />
                         </layer>
                      </staff>
-                     <hairpin staff="1 2 3 4" tstamp="2.000000" tstamp2="0m+4.0000" form="dim" place="below" />
+                     <hairpin staff="1 2 3 4" tstamp="2" tstamp2="0m+4" form="dim" place="below" />
                      <slur startid="#d690095e1542" endid="#d690095e1558" curvedir="above" />
                      <slur startid="#d690095e1580" endid="#d690095e1603" curvedir="above" />
                   </measure>

--- a/_tests/hairpin/hairpin-003.mei
+++ b/_tests/hairpin/hairpin-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -38,7 +38,7 @@
                            <note dur="1" oct="4" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+1.0000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="1m+1" form="cres" />
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -57,7 +57,7 @@
                            <space dots="1" dur="2" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+1.5000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+1.5" form="cres" />
                   </measure>
                </section>
             </score>

--- a/_tests/hairpin/hairpin-004.mei
+++ b/_tests/hairpin/hairpin-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+5.0000" form="cres" opening="5.000000vu" place="below" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+5" form="cres" opening="5.0000vu" place="below" />
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -74,7 +74,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+5.0000" color="#12AB00" form="cres" place="below" />
+                     <hairpin color="#12AB00" staff="1" tstamp="1" tstamp2="0m+5" form="cres" place="below" />
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -93,7 +93,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+5.0000" form="dim" opening="1.000000vu" place="below" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+5" form="dim" opening="1.0000vu" place="below" />
                   </measure>
                </section>
             </score>

--- a/_tests/hairpin/hairpin-005.mei
+++ b/_tests/hairpin/hairpin-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,7 @@
                      </staff>
                      <tie startid="#n13spws0" endid="#nhue6vb" />
                      <tie startid="#nhue6vb" endid="#n1g2ikqo" />
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+1.0000" form="cres" niente="true" opening="1.5000vu" />
+                     <hairpin staff="1" tstamp="1" tstamp2="1m+1" form="cres" niente="true" opening="1.5000vu" />
                   </measure>
                   <measure>
                      <staff n="1">
@@ -65,8 +65,8 @@
                            <rest dur="4" />
                         </layer>
                      </staff>
-                     <dynam staff="1" tstamp="1.000000">p</dynam>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+2.0000" form="dim" niente="true" opening="3.0000vu" />
+                     <dynam staff="1" tstamp="1">p</dynam>
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+2" form="dim" niente="true" opening="3.0000vu" />
                   </measure>
                </section>
             </score>

--- a/_tests/harm/harm-001.mei
+++ b/_tests/harm/harm-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -61,11 +61,11 @@
                            <note dur="4" oct="4" pname="d" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="3" tstamp="1.000000">G</harm>
-                     <harm place="below" staff="3" tstamp="3.000000">X</harm>
-                     <harm place="below" staff="3" tstamp="6.000000">D2</harm>
-                     <harm place="below" staff="3" tstamp="7.000000">C0</harm>
-                     <harm place="below" staff="3" tstamp="8.000000">D0</harm>
+                     <harm place="below" staff="3" tstamp="1">G</harm>
+                     <harm place="below" staff="3" tstamp="3">X</harm>
+                     <harm place="below" staff="3" tstamp="6">D2</harm>
+                     <harm place="below" staff="3" tstamp="7">C0</harm>
+                     <harm place="below" staff="3" tstamp="8">D0</harm>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -92,11 +92,11 @@
                            <note dur="2" oct="3" pname="a" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="3" tstamp="1.000000">C0</harm>
-                     <harm place="below" staff="3" tstamp="2.000000">E2</harm>
-                     <harm place="below" staff="3" tstamp="3.000000">F1</harm>
-                     <harm place="below" staff="3" tstamp="5.000000">G0</harm>
-                     <harm place="below" staff="3" tstamp="7.000000">A0</harm>
+                     <harm place="below" staff="3" tstamp="1">C0</harm>
+                     <harm place="below" staff="3" tstamp="2">E2</harm>
+                     <harm place="below" staff="3" tstamp="3">F1</harm>
+                     <harm place="below" staff="3" tstamp="5">G0</harm>
+                     <harm place="below" staff="3" tstamp="7">A0</harm>
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -125,9 +125,9 @@
                            <note dur="2" oct="4" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="3" tstamp="1.000000">G0</harm>
-                     <harm place="below" staff="3" tstamp="3.000000">C0</harm>
-                     <harm place="below" staff="3" tstamp="7.000000">C0</harm>
+                     <harm place="below" staff="3" tstamp="1">G0</harm>
+                     <harm place="below" staff="3" tstamp="3">C0</harm>
+                     <harm place="below" staff="3" tstamp="7">C0</harm>
                   </measure>
                </section>
             </score>

--- a/_tests/harm/harm-002.mei
+++ b/_tests/harm/harm-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,9 +28,9 @@
             <score>
                <scoreDef>
                   <staffGrp symbol="bracket">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="2" meter.unit="1" meter.sym="cut" />
-                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2" clef.dis="8" clef.dis.place="below" key.sig="0" meter.count="2" meter.unit="1" meter.sym="cut" />
-                     <staffDef n="3" lines="5" clef.shape="G" clef.line="2" clef.dis="8" clef.dis.place="below" key.sig="0" meter.count="2" meter.unit="1" meter.sym="cut" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="2" meter.unit="1" meter.sym="cut" />
+                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2" clef.dis="8" clef.dis.place="below" keysig="0" meter.count="2" meter.unit="1" meter.sym="cut" />
+                     <staffDef n="3" lines="5" clef.shape="G" clef.line="2" clef.dis="8" clef.dis.place="below" keysig="0" meter.count="2" meter.unit="1" meter.sym="cut" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -55,18 +55,18 @@
                            <note xml:id="note-L19F1" dur="2" oct="3" pname="a" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm staff="1" n="1" tstamp="1.000000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.000000">0</harm>
-                     <harm staff="1" n="1" tstamp="1.250000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.250000">2</harm>
-                     <harm staff="1" n="1" tstamp="1.500000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.500000">1</harm>
-                     <harm staff="1" n="1" tstamp="1.750000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.750000">2</harm>
-                     <harm staff="1" n="1" tstamp="2.000000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.000000">0</harm>
-                     <harm staff="1" n="1" tstamp="2.500000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.500000">1</harm>
+                     <harm staff="1" tstamp="1" n="1">4</harm>
+                     <harm staff="1" tstamp="1" n="2">0</harm>
+                     <harm staff="1" tstamp="1.25" n="1">4</harm>
+                     <harm staff="1" tstamp="1.25" n="2">2</harm>
+                     <harm staff="1" tstamp="1.5" n="1">4</harm>
+                     <harm staff="1" tstamp="1.5" n="2">1</harm>
+                     <harm staff="1" tstamp="1.75" n="1">4</harm>
+                     <harm staff="1" tstamp="1.75" n="2">2</harm>
+                     <harm staff="1" tstamp="2" n="1">2</harm>
+                     <harm staff="1" tstamp="2" n="2">0</harm>
+                     <harm staff="1" tstamp="2.5" n="1">2</harm>
+                     <harm staff="1" tstamp="2.5" n="2">1</harm>
                      <tie startid="#note-L19F1" endid="#note-L21F1" />
                   </measure>
                   <measure n="2">
@@ -88,13 +88,13 @@
                            <note dur="2" oct="3" pname="b" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm staff="1" n="1" tstamp="1.000000">4</harm>
-                     <harm staff="1" n="1" tstamp="1.250000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.250000">2</harm>
-                     <harm staff="1" n="1" tstamp="1.500000">1</harm>
-                     <harm staff="1" n="2" tstamp="1.500000">1</harm>
-                     <harm staff="1" n="1" tstamp="2.500000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.500000">1</harm>
+                     <harm staff="1" tstamp="1" n="1">4</harm>
+                     <harm staff="1" tstamp="1.25" n="1">4</harm>
+                     <harm staff="1" tstamp="1.25" n="2">2</harm>
+                     <harm staff="1" tstamp="1.5" n="1">1</harm>
+                     <harm staff="1" tstamp="1.5" n="2">1</harm>
+                     <harm staff="1" tstamp="2.5" n="1">2</harm>
+                     <harm staff="1" tstamp="2.5" n="2">1</harm>
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -119,18 +119,18 @@
                            <note xml:id="note-L31F1" dur="2" oct="3" pname="f" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm staff="1" n="1" tstamp="1.000000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.000000">0</harm>
-                     <harm staff="1" n="1" tstamp="1.250000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.250000">2</harm>
-                     <harm staff="1" n="1" tstamp="1.500000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.500000">1</harm>
-                     <harm staff="1" n="1" tstamp="1.750000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.750000">2</harm>
-                     <harm staff="1" n="1" tstamp="2.000000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.000000">0</harm>
-                     <harm staff="1" n="1" tstamp="2.500000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.500000">1</harm>
+                     <harm staff="1" tstamp="1" n="1">4</harm>
+                     <harm staff="1" tstamp="1" n="2">0</harm>
+                     <harm staff="1" tstamp="1.25" n="1">4</harm>
+                     <harm staff="1" tstamp="1.25" n="2">2</harm>
+                     <harm staff="1" tstamp="1.5" n="1">4</harm>
+                     <harm staff="1" tstamp="1.5" n="2">1</harm>
+                     <harm staff="1" tstamp="1.75" n="1">4</harm>
+                     <harm staff="1" tstamp="1.75" n="2">2</harm>
+                     <harm staff="1" tstamp="2" n="1">2</harm>
+                     <harm staff="1" tstamp="2" n="2">0</harm>
+                     <harm staff="1" tstamp="2.5" n="1">2</harm>
+                     <harm staff="1" tstamp="2.5" n="2">1</harm>
                      <tie startid="#note-L31F2" endid="#note-L33F2" />
                      <tie startid="#note-L31F1" endid="#note-L33F1" />
                   </measure>
@@ -155,15 +155,15 @@
                            <note dur="1" oct="3" pname="d" accid.ges="n" />
                         </layer>
                      </staff>
-                     <harm staff="1" n="1" tstamp="1.000000">4</harm>
-                     <harm staff="1" n="1" tstamp="1.250000">4</harm>
-                     <harm staff="1" n="2" tstamp="1.250000">2</harm>
-                     <harm staff="1" n="1" tstamp="1.500000">2</harm>
-                     <harm staff="1" n="2" tstamp="1.500000">1</harm>
-                     <harm staff="1" n="1" tstamp="2.000000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.000000">0</harm>
-                     <harm staff="1" n="1" tstamp="2.500000">2</harm>
-                     <harm staff="1" n="2" tstamp="2.500000">1</harm>
+                     <harm staff="1" tstamp="1" n="1">4</harm>
+                     <harm staff="1" tstamp="1.25" n="1">4</harm>
+                     <harm staff="1" tstamp="1.25" n="2">2</harm>
+                     <harm staff="1" tstamp="1.5" n="1">2</harm>
+                     <harm staff="1" tstamp="1.5" n="2">1</harm>
+                     <harm staff="1" tstamp="2" n="1">2</harm>
+                     <harm staff="1" tstamp="2" n="2">0</harm>
+                     <harm staff="1" tstamp="2.5" n="1">2</harm>
+                     <harm staff="1" tstamp="2.5" n="2">1</harm>
                   </measure>
                </section>
             </score>

--- a/_tests/harm/harm-003.mei
+++ b/_tests/harm/harm-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -89,7 +89,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">E♭m</harm>
+                     <harm staff="1" tstamp="1">E♭m</harm>
                   </measure>
                   <measure n="27">
                      <staff n="1">
@@ -118,7 +118,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">B♭/F</harm>
+                     <harm staff="1" tstamp="1">B♭/F</harm>
                   </measure>
                   <measure n="28">
                      <staff n="1">
@@ -135,8 +135,8 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">Gm</harm>
-                     <harm staff="1" tstamp="3.000000">Gdom</harm>
+                     <harm staff="1" tstamp="1">Gm</harm>
+                     <harm staff="1" tstamp="3">Gdom</harm>
                   </measure>
                   <measure n="29">
                      <staff n="1">
@@ -165,7 +165,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">Cm7</harm>
+                     <harm staff="1" tstamp="1">Cm7</harm>
                   </measure>
                </section>
             </score>

--- a/_tests/harm/harm-004.mei
+++ b/_tests/harm/harm-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="3" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="0" meter.count="3" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -40,8 +40,8 @@
                            <note dur="8" oct="4" pname="a" stem.dir="up" accid="f" />
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">F minor-seventh</harm>
-                     <harm staff="1" tstamp="2.500000">B♭ dominant</harm>
+                     <harm staff="1" tstamp="1">F minor-seventh</harm>
+                     <harm staff="1" tstamp="2.5">B♭ dominant</harm>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -51,7 +51,7 @@
                            <note dur="8" oct="4" pname="b" stem.dir="down" accid="f" />
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">E♭ maj</harm>
+                     <harm staff="1" tstamp="1">E♭ maj</harm>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -61,8 +61,8 @@
                            <note dur="8" oct="4" pname="a" stem.dir="up" accid="f" />
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">B♭ minor-seventh</harm>
-                     <harm staff="1" tstamp="3.500000">E♭ dominant</harm>
+                     <harm staff="1" tstamp="1">B♭ minor-seventh</harm>
+                     <harm staff="1" tstamp="3.5">E♭ dominant</harm>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -71,7 +71,7 @@
                            <rest dur="4" />
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">A♭ minor-major</harm>
+                     <harm staff="1" tstamp="1">A♭ minor-major</harm>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -81,8 +81,8 @@
                            <note dur="8" oct="4" pname="a" stem.dir="up" accid="f" />
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">F minor-seventh</harm>
-                     <harm staff="1" tstamp="2.500000">B♭ dominant</harm>
+                     <harm staff="1" tstamp="1">F minor-seventh</harm>
+                     <harm staff="1" tstamp="2.5">B♭ dominant</harm>
                   </measure>
                   <measure>
                      <staff n="1">
@@ -92,7 +92,7 @@
                            <note dur="8" oct="4" pname="b" stem.dir="down" accid="f" />
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">E♭ maj</harm>
+                     <harm staff="1" tstamp="1">E♭ maj</harm>
                   </measure>
                </section>
             </score>

--- a/_tests/harm/harm-005.mei
+++ b/_tests/harm/harm-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,12 +30,12 @@
                   <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
-                        <keySig pname="a" mode="major" sig="3s" />
+                        <keySig mode="major" sig="3s" pname="a" />
                         <meterSig count="4" sym="common" unit="4" />
                      </staffDef>
                      <staffDef n="2" lines="5">
                         <clef shape="F" line="4" />
-                        <keySig pname="a" mode="major" sig="3s" />
+                        <keySig mode="major" sig="3s" pname="a" />
                         <meterSig count="4" sym="common" unit="4" />
                      </staffDef>
                   </staffGrp>
@@ -61,10 +61,10 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm type="key-label" place="below" staff="2" tstamp="1.000000" n="1">
+                     <harm type="key-label" place="below" staff="2" tstamp="1" n="1">
                         <rend halign="right" fontweight="bold">VERY LONG LABEL:</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="1.000000" n="1">
+                     <harm place="below" staff="2" tstamp="1" n="1">
                         <rend>I</rend>
                      </harm>
                   </measure>
@@ -103,17 +103,17 @@
                            <note dur="4" oct="3" pname="d" accid="s" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="2" tstamp="1.000000" n="1">
+                     <harm place="below" staff="2" tstamp="1" n="1">
                         <rend>vi</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.000000" n="1">
+                     <harm place="below" staff="2" tstamp="2" n="1">
                         <rend>I<rend rend="sub">6</rend>
                         </rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="3.000000" n="1">
+                     <harm place="below" staff="2" tstamp="3" n="1">
                         <rend>IV</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="4.000000" n="1">
+                     <harm place="below" staff="2" tstamp="4" n="1">
                         <rend>V<rend rend="sub">6</rend>/V</rend>
                      </harm>
                   </measure>
@@ -150,25 +150,25 @@
                      </staff>
                      <fermata staff="1" startid="#note-L24F4" place="above" />
                      <fermata staff="2" startid="#note-L24F3" place="below" />
-                     <harm place="below" staff="2" tstamp="1.000000" n="1">
+                     <harm place="below" staff="2" tstamp="1" n="1">
                         <rend>v</rend>
                      </harm>
-                     <harm type="key-label" place="below" staff="2" tstamp="2.000000" n="1">
+                     <harm type="key-label" place="below" staff="2" tstamp="2" n="1">
                         <rend halign="right" fontweight="bold">LABEL:</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.000000" n="1">
+                     <harm place="below" staff="2" tstamp="2" n="1">
                         <rend>V/V</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="2.500000" n="1">
+                     <harm place="below" staff="2" tstamp="2.5" n="1">
                         <rend>(V<rend rend="sub">7</rend>/V)</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="3.000000" n="1">
+                     <harm place="below" staff="2" tstamp="3" n="1">
                         <rend>V</rend>
                      </harm>
-                     <harm type="key-label" place="below" staff="2" tstamp="4.000000" n="1">
+                     <harm type="key-label" place="below" staff="2" tstamp="4" n="1">
                         <rend halign="right" fontweight="bold">LABEL:</rend>
                      </harm>
-                     <harm place="below" staff="2" tstamp="4.000000" n="1">
+                     <harm place="below" staff="2" tstamp="4" n="1">
                         <rend>I</rend>
                      </harm>
                   </measure>

--- a/_tests/keysig/keysig-001.mei
+++ b/_tests/keysig/keysig-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -32,7 +32,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef midi.bpm="400" key.mode="aeolian" key.sig="5f" keysig.showchange="false">
+               <scoreDef midi.bpm="400" key.mode="aeolian" keysig="5f" keysig.cancelaccid="none">
                   <staffGrp bar.thru="false">
                      <staffDef n="1" lines="5" meter.count="4" meter.unit="2">
                         <label>Canto</label>

--- a/_tests/keysig/keysig-002.mei
+++ b/_tests/keysig/keysig-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef key.sig="4f" meter.sym="common">
+               <scoreDef keysig="4f" meter.sym="common">
                   <staffGrp>
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
@@ -47,7 +47,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <scoreDef keysig.show="true" key.sig="0" />
+                  <scoreDef keysig="0" keysig.visible="true" />
                   <measure right="dbl" n="4">
                      <staff n="1">
                         <layer n="1">
@@ -59,7 +59,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <scoreDef key.sig="2s" meter.sym="cut" />
+                  <scoreDef keysig="2s" meter.sym="cut" />
                   <measure n="2">
                      <staff n="1">
                         <layer n="1">
@@ -78,7 +78,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <scoreDef keysig.showchange="true" key.sig="5f" meter.count="4" meter.unit="4" />
+                  <scoreDef keysig="5f" keysig.cancelaccid="before" meter.count="4" meter.unit="4" />
                   <measure right="dbl" n="5">
                      <staff n="1">
                         <layer n="1">
@@ -90,7 +90,7 @@
                         </layer>
                      </staff>
                   </measure>
-                  <scoreDef key.sig="2s" />
+                  <scoreDef keysig="2s" />
                   <measure right="end" n="2">
                      <staff n="1">
                         <layer n="1">

--- a/_tests/keysig/keysig-003.mei
+++ b/_tests/keysig/keysig-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -40,7 +40,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="7s" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="7s" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -55,7 +55,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="C" clef.line="3" key.sig="7s" />
+                        <staffDef n="1" lines="5" clef.shape="C" clef.line="3" keysig="7s" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">
@@ -69,7 +69,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="C" clef.line="4" key.sig="7s" />
+                        <staffDef n="1" lines="5" clef.shape="C" clef.line="4" keysig="7s" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">
@@ -83,7 +83,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="F" clef.line="4" key.sig="7s" />
+                        <staffDef n="1" lines="5" clef.shape="F" clef.line="4" keysig="7s" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">
@@ -97,7 +97,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="7f" />
+                        <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="7f" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">
@@ -111,7 +111,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="C" clef.line="3" key.sig="7f" />
+                        <staffDef n="1" lines="5" clef.shape="C" clef.line="3" keysig="7f" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">
@@ -125,7 +125,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="C" clef.line="4" key.sig="7f" />
+                        <staffDef n="1" lines="5" clef.shape="C" clef.line="4" keysig="7f" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">
@@ -139,7 +139,7 @@
                <section restart="true">
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" lines="5" clef.shape="F" clef.line="4" key.sig="7f" />
+                        <staffDef n="1" lines="5" clef.shape="F" clef.line="4" keysig="7f" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="invis">

--- a/_tests/keysig/keysig-004.mei
+++ b/_tests/keysig/keysig-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -35,7 +35,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="11s" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="11f" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/keysig/keysig-005.mei
+++ b/_tests/keysig/keysig-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -12,7 +12,7 @@
                <persName role="encoder">David Bauer</persName>
                <persName role="encoder">Laurent Pugin</persName>
             </respStmt>
-            <date isodate="2022-09-29"></date>
+            <date isodate="2022-09-29" />
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>

--- a/_tests/layer/layer-001.mei
+++ b/_tests/layer/layer-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-002.mei
+++ b/_tests/layer/layer-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-003.mei
+++ b/_tests/layer/layer-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-004.mei
+++ b/_tests/layer/layer-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-005.mei
+++ b/_tests/layer/layer-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-CMN.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-006.mei
+++ b/_tests/layer/layer-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-007.mei
+++ b/_tests/layer/layer-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-008.mei
+++ b/_tests/layer/layer-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-009.mei
+++ b/_tests/layer/layer-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-010.mei
+++ b/_tests/layer/layer-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-011.mei
+++ b/_tests/layer/layer-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-012.mei
+++ b/_tests/layer/layer-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -229,9 +229,9 @@
                            <note xml:id="note-1164" dur="2" oct="2" pname="a" stem.dir="up" />
                         </layer>
                      </staff>
-                     <slur startid="#note-1163" tstamp2="4" />
-                     <dynam place="above" staff="2" tstamp="2.000000">dim.</dynam>
-                     <tie startid="#note-1164" tstamp2="4" />
+                     <slur startid="#note-1163" tstamp2="0m+4" />
+                     <dynam place="above" staff="2" tstamp="2">dim.</dynam>
+                     <tie startid="#note-1164" tstamp2="0m+4" />
                   </measure>
                </section>
             </score>

--- a/_tests/layer/layer-013.mei
+++ b/_tests/layer/layer-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/layer/layer-014.mei
+++ b/_tests/layer/layer-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,7 +36,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef midi.bpm="120.000000">
+               <scoreDef midi.bpm="120">
                   <staffGrp>
                      <staffDef n="1" lines="5" clef.shape="F" clef.line="4" keysig="1f" meter.count="4" meter.unit="4" meter.sym="common" />
                   </staffGrp>

--- a/_tests/layer/layer-015.mei
+++ b/_tests/layer/layer-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-001.mei
+++ b/_tests/lyric/lyric-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -100,7 +100,7 @@
                   <measure right="invis" n="4">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="bd3n512v1b4s1" dur="4" oct="3" pname="b" tie="t">
+                           <note xml:id="bd3n512v1b4s1" dur="4" oct="3" pname="b">
                               <verse>
                                  <syl>ing?</syl>
                               </verse>

--- a/_tests/lyric/lyric-002.mei
+++ b/_tests/lyric/lyric-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-003.mei
+++ b/_tests/lyric/lyric-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-004.mei
+++ b/_tests/lyric/lyric-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-005.mei
+++ b/_tests/lyric/lyric-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -143,8 +143,8 @@
                            <note dur="8" oct="3" pname="f" stem.dir="down" accid.ges="n" />
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegretto</tempo>
-                     <dynam staff="2" tstamp="1.000000">p</dynam>
+                     <tempo staff="1" tstamp="1">Allegretto</tempo>
+                     <dynam staff="2" tstamp="1">p</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -459,7 +459,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="cres" />
                   </measure>
                   <measure n="6">
                      <staff n="1">
@@ -561,7 +561,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="dim" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="dim" />
                   </measure>
                   <measure n="7">
                      <staff n="1">
@@ -666,7 +666,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="cres" />
                   </measure>
                   <measure n="8">
                      <staff n="1">
@@ -768,7 +768,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+2.5000" form="dim" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+2.5" form="dim" />
                   </measure>
                   <measure n="9">
                      <staff n="1">

--- a/_tests/lyric/lyric-006.mei
+++ b/_tests/lyric/lyric-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -142,8 +142,8 @@
                            <note dur="8" oct="3" pname="f" stem.dir="down" accid.ges="n" />
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegretto</tempo>
-                     <dynam staff="2" tstamp="1.000000">p</dynam>
+                     <tempo staff="1" tstamp="1">Allegretto</tempo>
+                     <dynam staff="2" tstamp="1">p</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -458,7 +458,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="cres" />
                   </measure>
                   <measure n="6">
                      <staff n="1">
@@ -560,7 +560,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="dim" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="dim" />
                   </measure>
                   <measure n="7">
                      <staff n="1">
@@ -665,7 +665,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="cres" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="cres" />
                   </measure>
                   <measure n="8">
                      <staff n="1">
@@ -767,7 +767,7 @@
                            <rest dur="8" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+2.5000" form="dim" />
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+2.5" form="dim" />
                   </measure>
                   <measure n="9">
                      <staff n="1">

--- a/_tests/lyric/lyric-007.mei
+++ b/_tests/lyric/lyric-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-008.mei
+++ b/_tests/lyric/lyric-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -38,7 +38,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="3" meter.unit="4" meter.form="invis" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="3" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -86,7 +86,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">E♭m</harm>
+                     <harm staff="1" tstamp="1">E♭m</harm>
                   </measure>
                   <measure n="27">
                      <staff n="1">
@@ -115,7 +115,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">B♭/F</harm>
+                     <harm staff="1" tstamp="1">B♭/F</harm>
                   </measure>
                   <sb />
                   <measure n="28">
@@ -133,8 +133,8 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">Gm</harm>
-                     <harm staff="1" tstamp="3.000000">Gdom</harm>
+                     <harm staff="1" tstamp="1">Gm</harm>
+                     <harm staff="1" tstamp="3">Gdom</harm>
                   </measure>
                   <measure n="29">
                      <staff n="1">
@@ -163,7 +163,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">Cm7</harm>
+                     <harm staff="1" tstamp="1">Cm7</harm>
                   </measure>
                   <measure n="30">
                      <staff n="1">
@@ -180,7 +180,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <harm staff="1" tstamp="1.000000">Fdom</harm>
+                     <harm staff="1" tstamp="1">Fdom</harm>
                   </measure>
                </section>
             </score>

--- a/_tests/lyric/lyric-009.mei
+++ b/_tests/lyric/lyric-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-010.mei
+++ b/_tests/lyric/lyric-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-011.mei
+++ b/_tests/lyric/lyric-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-012.mei
+++ b/_tests/lyric/lyric-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -33,7 +33,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="80">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
                         <keySig sig="0" />

--- a/_tests/lyric/lyric-013.mei
+++ b/_tests/lyric/lyric-013.mei
@@ -1,224 +1,224 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Handling of empty verse lines</title>
-        <respStmt>
-          <persName role="editor">Laurent Pugin</persName>
-          <persName role="encoder">Samuel Bradshaw</persName>
-        </respStmt>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2021-07-14">2021-07-14</date>
-        <pubPlace>
-          <ref target="https://github.com/rism-digital/verovio/issues/2241" />
-        </pubPlace>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Empty verse lines can be collapsed with the --lyric-verse-collapse option</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="3.5.0" label="2">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-    <extMeta><![CDATA[ { "lyricVerseCollapse": true } ]]></extMeta>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef>
-            <staffGrp>
-              <staffDef n="1" lines="5" ppq="8">
-                <instrDef midi.channel="0" midi.instrnum="0" midi.volume="80.00%" />
-                <clef shape="G" line="2" />
-                <keySig mode="major" sig="0" />
-                <meterSig count="3" unit="4" />
-              </staffDef>
-              <staffDef n="2" lines="5" ppq="2">
-                <instrDef midi.channel="0" midi.instrnum="0" midi.volume="80.00%" />
-                <clef shape="F" line="4" />
-                <keySig mode="major" sig="0" />
-                <meterSig count="3" unit="4" />
-              </staffDef>
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="4" stem.dir="up">
-                    <verse n="2">
-                      <label>2.</label>
-                      <syl con="s">“Come,</syl>
-                    </verse>
-                    <verse n="4">
-                      <label>4.</label>
-                      <syl con="s">Not</syl>
-                    </verse>
-                    <note oct="4" pname="c" />
-                    <note oct="4" pname="e" />
-                  </chord>
-                  <note dur="4" oct="4" pname="c" stem.dir="up">
-                    <verse n="2">
-                      <syl con="d" wordpos="i">fol</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="d" wordpos="i">on</syl>
-                    </verse>
-                  </note>
-                  <chord dur="4" stem.dir="up">
-                    <verse n="2">
-                      <syl con="s" wordpos="t">low</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="s" wordpos="t">ly</syl>
-                    </verse>
-                    <note oct="4" pname="c" />
-                    <note oct="4" pname="f" />
-                  </chord>
-                </layer>
-                <layer n="2">
-                  <space dur="4" />
-                  <note dur="4" oct="4" pname="c" stem.dir="down" />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <chord dur="4" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="3" pname="g" />
-                  </chord>
-                  <chord dur="4" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="3" pname="e" />
-                  </chord>
-                  <chord dur="4" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="3" pname="a" />
-                  </chord>
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <mNum />
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2" stem.dir="up">
-                    <verse n="2">
-                      <syl con="s">me,”</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="s">shall</syl>
-                    </verse>
-                    <note oct="4" pname="c" />
-                    <note oct="4" pname="e" />
-                  </chord>
-                  <chord dur="4" stem.dir="up">
-                    <verse n="2">
-                      <syl con="s">a</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="s">we</syl>
-                    </verse>
-                    <note oct="4" pname="e" />
-                    <note oct="4" pname="g" />
-                  </chord>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <chord dur="2" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="3" pname="g" />
-                  </chord>
-                  <chord dur="4" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="4" pname="c" />
-                  </chord>
-                </layer>
-              </staff>
-            </measure>
-            <measure n="3">
-              <mNum />
-              <staff n="1">
-                <layer n="1">
-                  <note dur="4" oct="5" pname="c" stem.dir="up" xml:id="n1">
-                    <verse n="2">
-                      <syl con="d" wordpos="i">sim</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="d" wordpos="i">em</syl>
-                    </verse>
-                  </note>
-                  <note dur="4" oct="4" pname="b" stem.dir="up" xml:id="n2" />
-                  <chord dur="4" stem.dir="up">
-                    <verse n="2">
-                      <syl con="s" wordpos="t">ple</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="d" wordpos="m">u</syl>
-                    </verse>
-                    <note oct="4" pname="f" />
-                    <note oct="4" pname="a" />
-                  </chord>
-                </layer>
-                <layer n="2">
-                  <note dur="2" oct="4" pname="f" stem.dir="down" />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <chord dur="2" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="3" pname="a" />
-                  </chord>
-                  <chord dur="4" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="3" pname="b" />
-                  </chord>
-                </layer>
-              </staff>
-              <slur startid="#n1" endid="#n2" curvedir="above" />
-            </measure>
-            <measure n="4">
-              <mNum />
-              <staff n="1">
-                <layer n="1">
-                  <chord dots="1" dur="2" stem.dir="up">
-                    <verse n="2">
-                      <syl con="s">phrase,</syl>
-                    </verse>
-                    <verse n="4">
-                      <syl con="s" wordpos="t">late</syl>
-                    </verse>
-                    <note oct="4" pname="e" />
-                    <note oct="4" pname="g" />
-                  </chord>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <chord dots="1" dur="2" stem.dir="down">
-                    <note oct="3" pname="c" />
-                    <note oct="4" pname="c" />
-                  </chord>
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Handling of empty verse lines</title>
+            <respStmt>
+               <persName role="editor">Laurent Pugin</persName>
+               <persName role="encoder">Samuel Bradshaw</persName>
+            </respStmt>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2021-07-14">2021-07-14</date>
+            <pubPlace>
+               <ref target="https://github.com/rism-digital/verovio/issues/2241" />
+            </pubPlace>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Empty verse lines can be collapsed with the --lyric-verse-collapse option</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="3.5.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+      <extMeta><![CDATA[ { "lyricVerseCollapse": true } ]]></extMeta>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" ppq="8">
+                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="80.00%" />
+                        <clef shape="G" line="2" />
+                        <keySig mode="major" sig="0" />
+                        <meterSig count="3" unit="4" />
+                     </staffDef>
+                     <staffDef n="2" lines="5" ppq="2">
+                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="80.00%" />
+                        <clef shape="F" line="4" />
+                        <keySig mode="major" sig="0" />
+                        <meterSig count="3" unit="4" />
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord xml:id="cp37zf7" dur="4" stem.dir="up">
+                              <verse n="2">
+                                 <label>2.</label>
+                                 <syl con="s">“Come,</syl>
+                              </verse>
+                              <verse n="4">
+                                 <label>4.</label>
+                                 <syl con="s">Not</syl>
+                              </verse>
+                              <note oct="4" pname="c" />
+                              <note oct="4" pname="e" />
+                           </chord>
+                           <note xml:id="n1ifz3br" dur="4" oct="4" pname="c" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="d" wordpos="i">fol</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="d" wordpos="i">on</syl>
+                              </verse>
+                           </note>
+                           <chord xml:id="c1pxbs6g" dur="4" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="s" wordpos="t">low</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="s" wordpos="t">ly</syl>
+                              </verse>
+                              <note oct="4" pname="c" />
+                              <note oct="4" pname="f" />
+                           </chord>
+                        </layer>
+                        <layer n="2">
+                           <space dur="4" />
+                           <note dur="4" oct="4" pname="c" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <chord dur="4" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="3" pname="g" />
+                           </chord>
+                           <chord dur="4" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="3" pname="e" />
+                           </chord>
+                           <chord dur="4" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="3" pname="a" />
+                           </chord>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <mNum />
+                     <staff n="1">
+                        <layer n="1">
+                           <chord xml:id="c18wihjl" dur="2" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="s">me,”</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="s">shall</syl>
+                              </verse>
+                              <note oct="4" pname="c" />
+                              <note oct="4" pname="e" />
+                           </chord>
+                           <chord xml:id="c14yxgrj" dur="4" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="s">a</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="s">we</syl>
+                              </verse>
+                              <note oct="4" pname="e" />
+                              <note oct="4" pname="g" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <chord dur="2" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="3" pname="g" />
+                           </chord>
+                           <chord dur="4" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="4" pname="c" />
+                           </chord>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <mNum />
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="n1" dur="4" oct="5" pname="c" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="d" wordpos="i">sim</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="d" wordpos="i">em</syl>
+                              </verse>
+                           </note>
+                           <note xml:id="n2" dur="4" oct="4" pname="b" stem.dir="up" />
+                           <chord xml:id="c16jepwq" dur="4" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="s" wordpos="t">ple</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="d" wordpos="m">u</syl>
+                              </verse>
+                              <note oct="4" pname="f" />
+                              <note oct="4" pname="a" />
+                           </chord>
+                        </layer>
+                        <layer n="2">
+                           <note dur="2" oct="4" pname="f" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <chord dur="2" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="3" pname="a" />
+                           </chord>
+                           <chord dur="4" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="3" pname="b" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <slur startid="#n1" endid="#n2" curvedir="above" />
+                  </measure>
+                  <measure n="4">
+                     <mNum />
+                     <staff n="1">
+                        <layer n="1">
+                           <chord xml:id="c18uj5o4" dots="1" dur="2" stem.dir="up">
+                              <verse n="2">
+                                 <syl con="s">phrase,</syl>
+                              </verse>
+                              <verse n="4">
+                                 <syl con="s" wordpos="t">late</syl>
+                              </verse>
+                              <note oct="4" pname="e" />
+                              <note oct="4" pname="g" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <chord dots="1" dur="2" stem.dir="down">
+                              <note oct="3" pname="c" />
+                              <note oct="4" pname="c" />
+                           </chord>
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/lyric/lyric-014.mei
+++ b/_tests/lyric/lyric-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -89,10 +89,10 @@
                            <note dur.ppq="2" dur="4" oct="3" pname="d" stem.dir="down" />
                         </layer>
                      </staff>
-                     <tempo place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="108.000000" mm="100.000000" mm.unit="4">
+                     <tempo place="above" staff="1" tstamp="1" xml:lang="it" midi.bpm="108" mm="100" mm.unit="4">
                         <rend fontfam="Palatino ldsLat Condensed Italic">Brightly</rend>
-                        <rend fontfam="smufl"></rend> = 100–108</tempo>
-                     <dir place="above" staff="1" tstamp="1.000000" vgrp="210">
+                        <rend glyph.auth="smufl"></rend> = 100–108</tempo>
+                     <dir place="above" staff="1" tstamp="1" vgrp="210">
                         <rend fontfam="DingPI ldsDpi">⌜</rend>
                      </dir>
                   </measure>
@@ -375,7 +375,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="3.000000" vgrp="210">
+                     <dir place="above" staff="1" tstamp="3" vgrp="210">
                         <rend halign="right" fontfam="DingPI ldsDpi">⌝</rend>
                      </dir>
                   </measure>

--- a/_tests/lyric/lyric-015.mei
+++ b/_tests/lyric/lyric-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/lyric/lyric-016.mei
+++ b/_tests/lyric/lyric-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -57,12 +57,12 @@
                            </note>
                            <note xml:id="n1307hjq" dur="4" oct="4" pname="a">
                               <verse n="1">
-                                 <syl letterspacing="2.000000" con="d" wordpos="i">wid</syl>
+                                 <syl letterspacing="2" con="d" wordpos="i">wid</syl>
                               </verse>
                            </note>
                            <note xml:id="n1l7mqx4" dur="4" oct="4" pname="b">
                               <verse n="1">
-                                 <syl letterspacing="2.000000" wordpos="t">der</syl>
+                                 <syl letterspacing="2" wordpos="t">der</syl>
                               </verse>
                               <accid accid.ges="f" />
                            </note>
@@ -74,19 +74,19 @@
                         <layer n="1">
                            <note xml:id="n1x8gfg1" dur="4" oct="5" pname="c">
                               <verse n="1">
-                                 <syl letterspacing="-0.200000" con="d" wordpos="i">nar</syl>
+                                 <syl letterspacing="-0.2" con="d" wordpos="i">nar</syl>
                               </verse>
                            </note>
                            <note xml:id="n1tuzjas" dur="4" oct="4" pname="b">
                               <verse n="1">
-                                 <syl letterspacing="-0.200000" con="d" wordpos="m">row</syl>
+                                 <syl letterspacing="-0.2" con="d" wordpos="m">row</syl>
                               </verse>
                               <accid accid.ges="f" />
                            </note>
                            <rest dur="4" />
                            <note xml:id="nnw3qi6" dur="4" oct="4" pname="g">
                               <verse n="1">
-                                 <syl letterspacing="-0.200000" con="u" wordpos="t">er</syl>
+                                 <syl letterspacing="-0.2" con="u" wordpos="t">er</syl>
                               </verse>
                            </note>
                         </layer>

--- a/_tests/measure/measure-001.mei
+++ b/_tests/measure/measure-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/metersig/metersig-002.mei
+++ b/_tests/metersig/metersig-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -43,6 +43,7 @@
             <score>
                <scoreDef midi.bpm="224">
                   <staffGrp bar.thru="true">
+                     <grpSym symbol="brace" />
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />
                         <meterSig count="3+3+2" unit="8" />
@@ -51,7 +52,6 @@
                         <clef shape="F" line="4" />
                         <meterSig count="3+3+2" unit="8" />
                      </staffDef>
-                     <grpSym symbol="brace" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -100,7 +100,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dynam place="between" staff="1 2" tstamp="1.000000">f</dynam>
+                     <dynam place="between" staff="1 2" tstamp="1">f</dynam>
                      <slur startid="#ex_1539979075" endid="#ex_0670571348" curvedir="above" />
                      <slur startid="#ex_0988481891" endid="#ex_1206272372" curvedir="above" />
                      <slur startid="#ex_0644303028" endid="#ex_0423192807" curvedir="above" />

--- a/_tests/metersig/metersig-003.mei
+++ b/_tests/metersig/metersig-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/metersig/metersig-004.mei
+++ b/_tests/metersig/metersig-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -37,7 +37,7 @@
                   <staffGrp>
                      <staffDef n="1" lines="5" key.mode="major" keysig="0">
                         <clef shape="G" line="2" />
-                        <meterSig count="3" enclose="paren" unit="8" />
+                        <meterSig enclose="paren" count="3" unit="8" />
                      </staffDef>
                   </staffGrp>
                </scoreDef>
@@ -54,7 +54,7 @@
                      </staff>
                   </measure>
                   <scoreDef n="1">
-                     <meterSig count="3" enclose="paren" unit="8" form="num"/>
+                     <meterSig enclose="paren" count="3" unit="8" form="num" />
                   </scoreDef>
                   <measure n="1">
                      <staff n="1">
@@ -68,7 +68,7 @@
                      </staff>
                   </measure>
                   <scoreDef n="1">
-                     <meterSig sym="cut" enclose="paren"/>
+                     <meterSig enclose="paren" sym="cut" />
                   </scoreDef>
                   <measure right="end" n="1">
                      <staff n="1">

--- a/_tests/metersig/metersig-005.mei
+++ b/_tests/metersig/metersig-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mnum/mnum-001.mei
+++ b/_tests/mnum/mnum-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mordent/mordent-001.mei
+++ b/_tests/mordent/mordent-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mordent/mordent-002.mei
+++ b/_tests/mordent/mordent-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mordent/mordent-003.mei
+++ b/_tests/mordent/mordent-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mordent/mordent-004.mei
+++ b/_tests/mordent/mordent-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mordent/mordent-005.mei
+++ b/_tests/mordent/mordent-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -56,8 +56,8 @@
                      </staff>
                      <mordent staff="1" startid="#note-L3F1" form="upper" />
                      <mordent staff="1" startid="#note-L6F1" form="upper" />
-                     <mordent staff="1" startid="#note-L5F2" color="limegreen" form="upper" />
-                     <mordent staff="1" startid="#note-L6F2" color="limegreen" form="upper" />
+                     <mordent color="limegreen" staff="1" startid="#note-L5F2" form="upper" />
+                     <mordent color="limegreen" staff="1" startid="#note-L6F2" form="upper" />
                   </measure>
                   <measure n="1">
                      <staff n="1">
@@ -73,8 +73,8 @@
                         </layer>
                      </staff>
                      <trill staff="1" startid="#note-L12F1" />
-                     <trill staff="1" startid="#note-L14F2" color="limegreen" />
-                     <trill staff="1" startid="#note-L15F2" color="limegreen" />
+                     <trill color="limegreen" staff="1" startid="#note-L14F2" />
+                     <trill color="limegreen" staff="1" startid="#note-L15F2" />
                   </measure>
                </section>
             </score>

--- a/_tests/note/note-001.mei
+++ b/_tests/note/note-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="5f" meter.count="2" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="5f" meter.count="2" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/note/note-002.mei
+++ b/_tests/note/note-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/note/note-003.mei
+++ b/_tests/note/note-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/note/note-004.mei
+++ b/_tests/note/note-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/note/note-005.mei
+++ b/_tests/note/note-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -32,7 +32,7 @@
             <score>
                <scoreDef midi.bpm="72">
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="1s" meter.count="2" meter.unit="2" meter.sym="cut" />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1s" meter.count="2" meter.unit="2" meter.sym="cut" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/note/note-006.mei
+++ b/_tests/note/note-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
             <score>
                <scoreDef>
                   <staffGrp symbol="bracket">
-                     <staffDef label="Violino I" n="1" lines="5" clef.shape="G" clef.line="2" key.sig="1f" />
+                     <staffDef label="Violino I" n="1" lines="5" clef.shape="G" clef.line="2" keysig="1f" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/note/note-007.mei
+++ b/_tests/note/note-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/note/note-008.mei
+++ b/_tests/note/note-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -32,8 +32,8 @@
             <score>
                <scoreDef>
                   <staffGrp symbol="bracket">
-                     <staffDef label="Violino I" n="1" lines="5" clef.shape="G" clef.line="2" key.sig="1f" />
-                     <staffDef label="Violino I" n="2" lines="5" clef.shape="G" clef.line="2" key.sig="1f" />
+                     <staffDef label="Violino I" n="1" lines="5" clef.shape="G" clef.line="2" keysig="1f" />
+                     <staffDef label="Violino I" n="2" lines="5" clef.shape="G" clef.line="2" keysig="1f" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/note/note-009.mei
+++ b/_tests/note/note-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/note/note-010.mei
+++ b/_tests/note/note-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/note/note-011.mei
+++ b/_tests/note/note-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/octave/octave-001.mei
+++ b/_tests/octave/octave-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/octave/octave-002.mei
+++ b/_tests/octave/octave-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -76,7 +76,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n3" tstamp2="1m+4.0000" dis="15" dis.place="below" />
+                     <octave startid="#n3" tstamp2="1m+4" dis="15" dis.place="below" />
                   </measure>
                   <measure right="dbl" n="5">
                      <staff n="1">

--- a/_tests/octave/octave-003.mei
+++ b/_tests/octave/octave-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -68,7 +68,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n3" tstamp2="1m+4.0000" lform="solid" dis="8" dis.place="above" />
+                     <octave startid="#n3" tstamp2="1m+4" lform="solid" dis="8" dis.place="above" />
                   </measure>
                   <measure right="dbl" n="5">
                      <staff n="1">

--- a/_tests/octave/octave-004.mei
+++ b/_tests/octave/octave-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/ornam/ornam-001.mei
+++ b/_tests/ornam/ornam-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/pedal/pedal-001.mei
+++ b/_tests/pedal/pedal-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef key.mode="minor" keysig="4f" meter.count="6" meter.unit="8">
-                  <staffGrp label="Piano" symbol="brace" bar.thru="true">
+                  <staffGrp label="Piano" bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>
@@ -79,17 +79,17 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1" tstamp="1.000000">p</dynam>
-                     <dir place="below" staff="2" tstamp="1.000000">legatissimo</dir>
-                     <tempo place="above" staff="1" tstamp="1.000000">Allegro molto agitato</tempo>
+                     <dynam place="below" staff="1" tstamp="1">p</dynam>
+                     <dir place="below" staff="2" tstamp="1">legatissimo</dir>
+                     <tempo place="above" staff="1" tstamp="1">Allegro molto agitato</tempo>
                      <slur startid="#d414233e38" endid="#d414233e62" curvedir="below" />
                      <slur startid="#d414233e89" endid="#d414233e110" curvedir="below" />
                      <slur startid="#d414233e148" endid="#d414233e242" curvedir="above" />
                      <slur startid="#d414233e260" endid="#d414233e353" curvedir="above" />
-                     <pedal staff="2" tstamp="1.000000" dir="down" />
-                     <pedal staff="2" tstamp="3.500000" dir="up" />
-                     <pedal staff="2" tstamp="4.000000" dir="down" />
-                     <pedal staff="2" tstamp="6.500000" dir="up" />
+                     <pedal staff="2" tstamp="1" dir="down" />
+                     <pedal staff="2" tstamp="3.5" dir="up" />
+                     <pedal staff="2" tstamp="4" dir="down" />
+                     <pedal staff="2" tstamp="6.5" dir="up" />
                   </measure>
                   <measure n="2">
                      <staff n="1">
@@ -136,13 +136,13 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dir place="below" staff="1" tstamp="1.000000">cresc.</dir>
-                     <hairpin staff="1" tstamp="3.000000" tstamp2="0m+6.5000" form="cres" place="below" />
-                     <slur startid="#d414233e381" tstamp2="0m+7.0000" curvedir="above" />
-                     <pedal staff="2" tstamp="1.000000" dir="down" />
-                     <pedal staff="2" tstamp="3.500000" dir="up" />
-                     <pedal staff="2" tstamp="4.000000" dir="down" />
-                     <pedal staff="2" tstamp="6.500000" dir="up" />
+                     <dir place="below" staff="1" tstamp="1">cresc.</dir>
+                     <hairpin staff="1" tstamp="3" tstamp2="0m+6.5" form="cres" place="below" />
+                     <slur startid="#d414233e381" tstamp2="0m+7" curvedir="above" />
+                     <pedal staff="2" tstamp="1" dir="down" />
+                     <pedal staff="2" tstamp="3.5" dir="up" />
+                     <pedal staff="2" tstamp="4" dir="down" />
+                     <pedal staff="2" tstamp="6.5" dir="up" />
                   </measure>
                </section>
             </score>

--- a/_tests/pedal/pedal-002.mei
+++ b/_tests/pedal/pedal-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/pedal/pedal-003.mei
+++ b/_tests/pedal/pedal-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -44,8 +44,8 @@
                            <note dur="4" oct="3" pname="d" />
                         </layer>
                      </staff>
-                     <pedal staff="1" tstamp="1.000000" dir="down" form="line" />
-                     <pedal staff="1" tstamp="5.000000" dir="up" form="line" />
+                     <pedal staff="1" tstamp="1" dir="down" form="line" />
+                     <pedal staff="1" tstamp="5" dir="up" form="line" />
                   </measure>
                   <measure>
                      <staff n="1">
@@ -56,10 +56,10 @@
                            <note dur="4" oct="3" pname="d" />
                         </layer>
                      </staff>
-                     <pedal staff="1" tstamp="1.000000" dir="down" form="line" />
-                     <pedal staff="1" tstamp="2.500000" dir="up" form="line" />
-                     <pedal staff="1" tstamp="3.000000" dir="down" form="line" />
-                     <pedal staff="1" tstamp="4.500000" dir="up" form="line" />
+                     <pedal staff="1" tstamp="1" dir="down" form="line" />
+                     <pedal staff="1" tstamp="2.5" dir="up" form="line" />
+                     <pedal staff="1" tstamp="3" dir="down" form="line" />
+                     <pedal staff="1" tstamp="4.5" dir="up" form="line" />
                   </measure>
                </section>
             </score>

--- a/_tests/pedal/pedal-004.mei
+++ b/_tests/pedal/pedal-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/pedal/pedal-005.mei
+++ b/_tests/pedal/pedal-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -51,12 +51,12 @@
                            <note dur="2" oct="4" pname="d" accid.ges="n" />
                         </layer>
                      </staff>
-                     <pedal staff="1" tstamp="1.000000" dir="down" vgrp="2" />
-                     <dynam staff="1" tstamp="1.000000" vgrp="1">p</dynam>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+3.0000" form="cres" vgrp="1" />
-                     <dynam staff="1" tstamp="3.000000" vgrp="1">f</dynam>
-                     <hairpin staff="1" tstamp="3.500000" tstamp2="0m+4.5000" form="dim" vgrp="1" />
-                     <pedal staff="1" tstamp="5.000000" dir="up" vgrp="2" />
+                     <pedal staff="1" tstamp="1" dir="down" vgrp="2" />
+                     <dynam staff="1" tstamp="1" vgrp="1">p</dynam>
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+3" form="cres" vgrp="1" />
+                     <dynam staff="1" tstamp="3" vgrp="1">f</dynam>
+                     <hairpin staff="1" tstamp="3.5" tstamp2="0m+4.5" form="dim" vgrp="1" />
+                     <pedal staff="1" tstamp="5" dir="up" vgrp="2" />
                   </measure>
                </section>
             </score>

--- a/_tests/pedal/pedal-006.mei
+++ b/_tests/pedal/pedal-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -44,8 +44,8 @@
                            <note dur="4" oct="3" pname="d" />
                         </layer>
                      </staff>
-                     <pedal staff="1" tstamp="1.000000" dir="down" form="pedline" />
-                     <pedal staff="1" tstamp="5.000000" dir="up" form="pedline" />
+                     <pedal staff="1" tstamp="1" dir="down" form="pedline" />
+                     <pedal staff="1" tstamp="5" dir="up" form="pedline" />
                   </measure>
                   <measure>
                      <staff n="1">
@@ -56,10 +56,10 @@
                            <note dur="4" oct="3" pname="d" />
                         </layer>
                      </staff>
-                     <pedal staff="1" tstamp="1.000000" dir="down" form="pedline" />
-                     <pedal staff="1" tstamp="2.500000" dir="up" form="pedline" />
-                     <pedal staff="1" tstamp="3.000000" dir="down" form="pedline" />
-                     <pedal staff="1" tstamp="4.500000" dir="up" form="pedline" />
+                     <pedal staff="1" tstamp="1" dir="down" form="pedline" />
+                     <pedal staff="1" tstamp="2.5" dir="up" form="pedline" />
+                     <pedal staff="1" tstamp="3" dir="down" form="pedline" />
+                     <pedal staff="1" tstamp="4.5" dir="up" form="pedline" />
                   </measure>
                </section>
             </score>

--- a/_tests/pgfoot/pghead-001.mei
+++ b/_tests/pgfoot/pghead-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/phrase/phrase-001.mei
+++ b/_tests/phrase/phrase-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rend/rend-001.mei
+++ b/_tests/rend/rend-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -56,7 +56,7 @@
                            <note dur="1" oct="4" pname="f" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="5.000000">
+                     <dir place="above" staff="1" tstamp="5">
                         <rend halign="right" fontstyle="normal">some text</rend>
                      </dir>
                   </measure>
@@ -81,7 +81,7 @@
                            <note dur="1" oct="4" pname="e" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="below" staff="1" tstamp="5.000000">
+                     <dir place="below" staff="1" tstamp="5">
                         <rend halign="right">fine</rend>
                      </dir>
                   </measure>

--- a/_tests/rend/rend-002.mei
+++ b/_tests/rend/rend-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rend/rend-003.mei
+++ b/_tests/rend/rend-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="encoder">Laurent Pugin</persName>
             </respStmt>
-            <date isodate="2022-10-06"></date>
+            <date isodate="2022-10-06" />
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>
@@ -54,10 +54,11 @@
                         </layer>
                      </staff>
                      <dir place="above" staff="1" tstamp="1">
-                        <rend rend="box" fontsize="50%">Text at 50% with <rend fontsize="200%">text a 200%</rend> but not all</rend>
+                        <rend rend="box" fontsize="50.00%">Text at 50% with <rend fontsize="200.00%">text a 200%</rend> but not all</rend>
                      </dir>
                      <dir place="below" staff="1" tstamp="1">
-                        <rend fontsize="75%">Text at 75% with <rend fontsize="smaller">smaller <rend fontsize="smaller">and even smaller</rend></rend> text</rend>
+                        <rend fontsize="75.00%">Text at 75% with <rend fontsize="smaller">smaller <rend fontsize="smaller">and even smaller</rend>
+                           </rend> text</rend>
                      </dir>
                   </measure>
                   <measure>
@@ -71,10 +72,12 @@
                         </layer>
                      </staff>
                      <dir place="above" staff="1" tstamp="3">
-                        <rend  fontsize="large" fontstyle="normal">large <symbol glyph.auth="smufl" glyph.name="ornamentTrill"></symbol></rend>
+                        <rend fontsize="large" fontstyle="normal">large <symbol glyph.auth="smufl" glyph.name="ornamentTrill" />
+                        </rend>
                      </dir>
                      <dir place="below" staff="1" tstamp="3">
-                        <rend rend="circle" fontsize="x-small" fontstyle="normal">x-small <symbol glyph.auth="smufl" glyph.name="ornamentTrill"></symbol></rend>
+                        <rend rend="circle" fontsize="x-small" fontstyle="normal">x-small <symbol glyph.auth="smufl" glyph.name="ornamentTrill" />
+                        </rend>
                      </dir>
                   </measure>
                </section>

--- a/_tests/rend/rend-004.mei
+++ b/_tests/rend/rend-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -51,11 +51,11 @@
                            </note>
                         </layer>
                      </staff>
-                     <tempo startid="#n1312x8i" midi.bpm="63.000000">
+                     <tempo startid="#n1312x8i" midi.bpm="63">
                         <rend>Normal spacing</rend>
                      </tempo>
                      <dir type="mscore-playtech-annotation" startid="#n13uobqg">
-                        <rend letterspacing="2.000000">wider</rend>
+                        <rend letterspacing="2">wider</rend>
                      </dir>
                   </measure>
                   <measure n="2">
@@ -70,7 +70,7 @@
                         </layer>
                      </staff>
                      <dir type="mscore-playtech-annotation" startid="#nwmr6bu">
-                        <rend letterspacing="-0.200000">narrower spacing</rend>
+                        <rend letterspacing="-0.2">narrower spacing</rend>
                      </dir>
                   </measure>
                   <measure right="end" n="3">

--- a/_tests/repeatmark/repeatmark-001.mei
+++ b/_tests/repeatmark/repeatmark-001.mei
@@ -1,90 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>Repeat marks example</title>
-            </titleStmt>
-            <pubStmt>
-                <date isodate="2023-06-13" />
-            </pubStmt>
-            <seriesStmt>
-                <title>Verovio test suite</title>
-            </seriesStmt>
-            <notesStmt>
-                <annot>Verovio supports default repeat marks encoded with repeatMark@func.</annot>
-            </notesStmt>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application version="3.16.0" label="1">
-                    <name>Verovio</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv>
-                <score>
-                    <scoreDef keysig="4f" meter.sym="common">
-                        <staffGrp>
-                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-                        </staffGrp>
-                    </scoreDef>
-                    <section>
-                        <measure n="1">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="coda"/>
-                        </measure>
-                        <measure n="2">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="segno"/>
-                        </measure>
-                        <measure n="3">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="daCapo"/>
-                        </measure>
-                        <measure n="4">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="dalSegno"/>
-                        </measure>
-                        <measure n="5" right="dbl">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="fine"/>
-                        </measure>
-                        <measure right="end" n="2">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Repeat marks example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2023-06-13" />
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports default repeat marks encoded with repeatMark@func.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="3.16.0" label="1">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef keysig="4f" meter.sym="common">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="coda" />
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="segno" />
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="daCapo" />
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="dalSegno" />
+                  </measure>
+                  <measure right="dbl" n="5">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="fine" />
+                  </measure>
+                  <measure right="end" n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/repeatmark/repeatmark-002.mei
+++ b/_tests/repeatmark/repeatmark-002.mei
@@ -1,104 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>Repeat marks with symbols and text example</title>
-            </titleStmt>
-            <pubStmt>
-                <date isodate="2023-06-13" />
-            </pubStmt>
-            <seriesStmt>
-                <title>Verovio test suite</title>
-            </seriesStmt>
-            <notesStmt>
-                <annot>Verovio supports repeat marks encoded symbols or text content.</annot>
-            </notesStmt>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application version="3.16.0" label="1">
-                    <name>Verovio</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv>
-                <score>
-                    <scoreDef keysig="4f" meter.sym="common">
-                        <staffGrp>
-                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-                        </staffGrp>
-                    </scoreDef>
-                    <section>
-                        <measure n="1">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="coda" glyph.auth="smufl" glyph.name="codaSquare"/>
-                        </measure>
-                        <measure n="2">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="segno" glyph.auth="smufl" glyph.num="U+E04A"/>
-                        </measure>
-                        <measure n="3">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="daCapo"><rend fontstyle="italic">Da capo al fine</rend></repeatMark>
-                        </measure>
-                        <measure n="4">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="5">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="dalSegno">Dal <symbol glyph.auth="smufl" glyph.name="segno" color="orange"/> al fine</repeatMark>
-                        </measure>
-                        <measure n="6">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="7" right="dbl">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                            <repeatMark tstamp="0.0" staff="1" func="fine">(Fine)</repeatMark>
-                        </measure>
-                        <measure right="end" n="8">
-                            <staff n="1">
-                                <layer n="1">
-                                    <mRest />
-                                </layer>
-                            </staff>
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Repeat marks with symbols and text example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2023-06-13" />
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports repeat marks encoded symbols or text content.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="3.16.0" label="1">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef keysig="4f" meter.sym="common">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" glyph.auth="smufl" glyph.name="codaSquare" func="coda" />
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" glyph.auth="smufl" glyph.num="U+E04A" func="segno" />
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="daCapo">
+                        <rend fontstyle="italic">Da capo al fine</rend>
+                     </repeatMark>
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="5">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="dalSegno">Dal <symbol color="orange" glyph.auth="smufl" glyph.name="segno" /> al fine</repeatMark>
+                  </measure>
+                  <measure n="6">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure right="dbl" n="7">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                     <repeatMark staff="1" tstamp="0" func="fine">(Fine)</repeatMark>
+                  </measure>
+                  <measure right="end" n="8">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRest />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/repeats/rpt-001.mei
+++ b/_tests/repeats/rpt-001.mei
@@ -1,128 +1,128 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Measure repetition example</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017-05-04">2017-05-04</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Verovio supports measure repetition signs. The number on top of each repetition sign is calculated by Verovio, and its rendering is optional.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="2.0.0" label="2">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef meter.count="6" meter.unit="8">
-            <staffGrp symbol="bracket">
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-              <staffDef multi.number="false" n="2" lines="5" clef.shape="F" clef.line="4" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                  </beam>
-                  <beam>
-                    <note dur="8" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                    <note dur="8" oct="4" pname="g" />
-                  </beam>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dots="1" dur="2" oct="3" pname="f" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <supplied>
-                    <mRpt />
-                  </supplied>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <mRpt />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <mRpt />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <mRpt />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="4">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="16" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="g" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="4" pname="b" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                  </beam>
-                  <beam>
-                    <note dur="8" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                    <note dur="8" oct="4" pname="c" />
-                  </beam>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <mRpt />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="5">
-              <staff n="1">
-                <layer n="1">
-                  <mRpt />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <mRpt />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Measure repetition example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017-05-04">2017-05-04</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports measure repetition signs. The number on top of each repetition sign is calculated by Verovio, and its rendering is optional.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="6" meter.unit="8">
+                  <staffGrp symbol="bracket">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef multi.number="false" n="2" lines="5" clef.shape="F" clef.line="4" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                           </beam>
+                           <beam>
+                              <note dur="8" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                              <note dur="8" oct="4" pname="g" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dots="1" dur="2" oct="3" pname="f" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <supplied>
+                              <mRpt />
+                           </supplied>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <mRpt />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRpt />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <mRpt />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="16" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="g" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="4" pname="b" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                           </beam>
+                           <beam>
+                              <note dur="8" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                              <note dur="8" oct="4" pname="c" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <mRpt />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="5">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRpt />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <mRpt />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/repeats/rpt-002.mei
+++ b/_tests/repeats/rpt-002.mei
@@ -1,82 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Two-measure repetition example</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017-05-09">2017-05-09</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Verovio supports repetition signs for two measures with the element "mRpt2".</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="2.0.0" label="2">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef meter.count="2" meter.unit="4">
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="g" />
-                    <note dur="16" oct="4" pname="a" />
-                  </beam>
-                  <beam>
-                    <note dur="8" oct="5" pname="c" />
-                    <note dur="16" oct="4" pname="b" />
-                    <note dur="16" oct="4" pname="g" />
-                  </beam>
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="5" pname="c" />
-                  </beam>
-                  <beam>
-                    <note dur="8" oct="5" pname="d" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="16" oct="4" pname="g" />
-                  </beam>
-                </layer>
-              </staff>
-            </measure>
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <mRpt2 />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Two-measure repetition example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017-05-09">2017-05-09</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports repetition signs for two measures with the element "mRpt2".</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="2" meter.unit="4">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="g" />
+                              <note dur="16" oct="4" pname="a" />
+                           </beam>
+                           <beam>
+                              <note dur="8" oct="5" pname="c" />
+                              <note dur="16" oct="4" pname="b" />
+                              <note dur="16" oct="4" pname="g" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="5" pname="c" />
+                           </beam>
+                           <beam>
+                              <note dur="8" oct="5" pname="d" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="16" oct="4" pname="g" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <mRpt2 />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/repeats/rpt-003.mei
+++ b/_tests/repeats/rpt-003.mei
@@ -1,106 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Half-measure repetition example</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017-05-04">2017-05-04</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Verovio supports half-measure repetition signs.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="2.0.0" label="2">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef meter.count="6" meter.unit="8">
-            <staffGrp symbol="bracket">
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-              <staffDef multi.number="false" n="2" lines="5" clef.shape="F" clef.line="4" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                  </beam>
-                  <halfmRpt />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dots="1" dur="4" oct="3" pname="f" />
-                  <note dots="1" dur="4" oct="3" pname="f" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                  </beam>
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                  </beam>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dots="1" dur="4" oct="3" pname="f" />
-                  <halfmRpt />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="f" />
-                    <note dur="16" oct="4" pname="a" />
-                    <note dur="16" oct="5" pname="c" />
-                    <note dur="8" oct="4" pname="a" />
-                  </beam>
-                  <halfmRpt />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dots="1" dur="4" oct="3" pname="f" />
-                  <halfmRpt />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Half-measure repetition example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017-05-04">2017-05-04</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports half-measure repetition signs.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="6" meter.unit="8">
+                  <staffGrp symbol="bracket">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef multi.number="false" n="2" lines="5" clef.shape="F" clef.line="4" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                           </beam>
+                           <halfmRpt />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="3" pname="f" />
+                           <note dots="1" dur="4" oct="3" pname="f" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                           </beam>
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="3" pname="f" />
+                           <halfmRpt />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="f" />
+                              <note dur="16" oct="4" pname="a" />
+                              <note dur="16" oct="5" pname="c" />
+                              <note dur="8" oct="4" pname="a" />
+                           </beam>
+                           <halfmRpt />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="3" pname="f" />
+                           <halfmRpt />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/repeats/rpt-004.mei
+++ b/_tests/repeats/rpt-004.mei
@@ -1,77 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Multi-measure repeat example</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017-05-09">2017-05-09</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Verovio supports repetition signs for more than two measures with the element "multiRpt". The number of measures to be repeted has to be provided in the attribute "num".</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="2.0.0" label="2">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef meter.count="2" meter.unit="4">
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <note dots="1" dur="4" oct="4" pname="f" />
-                  <note dur="8" oct="4" pname="a" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <note dots="1" dur="4" oct="5" pname="c" />
-                  <note dur="8" oct="5" pname="d" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="5" pname="f" />
-                    <note dur="8" oct="5" pname="d" />
-                  </beam>
-                  <note dur="4" oct="5" pname="c" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="4">
-              <staff n="1">
-                <layer n="1">
-                  <multiRpt num="3" />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Multi-measure repeat example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017-05-09">2017-05-09</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports repetition signs for more than two measures with the element "multiRpt". The number of measures to be repeted has to be provided in the attribute "num".</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="2" meter.unit="4">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="4" pname="f" />
+                           <note dur="8" oct="4" pname="a" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="5" pname="c" />
+                           <note dur="8" oct="5" pname="d" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="5" pname="f" />
+                              <note dur="8" oct="5" pname="d" />
+                           </beam>
+                           <note dur="4" oct="5" pname="c" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <multiRpt num="3" />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/repeats/rpt-005.mei
+++ b/_tests/repeats/rpt-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/repeats/rpt-006.mei
+++ b/_tests/repeats/rpt-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/repeats/rpt-007.mei
+++ b/_tests/repeats/rpt-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -78,7 +78,7 @@
                               <note dur="8" oct="3" pname="g" accid.ges="n" />
                               <note dur="8" oct="4" pname="c" accid.ges="n" />
                            </beam>
-                           <beatRpt beatdef="3.000000" slash="1" />
+                           <beatRpt beatdef="3" slash="1" />
                            <beam>
                               <note dur="8" oct="3" pname="f" accid.ges="n" />
                               <note dur="8" oct="3" pname="b" accid.ges="n" />

--- a/_tests/repeats/rpt-008.mei
+++ b/_tests/repeats/rpt-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -66,14 +66,14 @@
                               <note dur="16" oct="3" pname="e" accid.ges="n" />
                               <note dur="16" oct="3" pname="f" accid.ges="n" />
                            </beam>
-                           <beatRpt beatdef="0.500000" slash="2" />
+                           <beatRpt beatdef="0.5" slash="2" />
                            <beam>
                               <note dur="16" oct="3" pname="d" accid.ges="n" />
                               <note dur="16" oct="3" pname="e" accid.ges="n" />
                               <note dur="16" oct="3" pname="f" accid.ges="n" />
                               <note dur="16" oct="3" pname="g" accid.ges="n" />
                            </beam>
-                           <beatRpt beatdef="0.500000" slash="2" />
+                           <beatRpt beatdef="0.5" slash="2" />
                            <rest dur="4" />
                            <rest dur="4" />
                            <rest dur="4" />

--- a/_tests/rest/rest-001.mei
+++ b/_tests/rest/rest-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-002.mei
+++ b/_tests/rest/rest-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-003.mei
+++ b/_tests/rest/rest-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-004.mei
+++ b/_tests/rest/rest-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-005.mei
+++ b/_tests/rest/rest-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1s" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="1s" />
                   </staffGrp>

--- a/_tests/rest/rest-006.mei
+++ b/_tests/rest/rest-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-007.mei
+++ b/_tests/rest/rest-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-008.mei
+++ b/_tests/rest/rest-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-009.mei
+++ b/_tests/rest/rest-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-010.mei
+++ b/_tests/rest/rest-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-011.mei
+++ b/_tests/rest/rest-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -49,13 +49,13 @@
                            <beam>
                               <tuplet num="3" numbase="2" bracket.visible="false">
                                  <bTrem unitdur="16">
-                                    <note pname="b" oct="5" dur="8" />
+                                    <note dur="8" oct="5" pname="b" />
                                  </bTrem>
                                  <bTrem unitdur="16">
-                                    <note pname="a" oct="5" dur="8" />
+                                    <note dur="8" oct="5" pname="a" />
                                  </bTrem>
                                  <bTrem unitdur="16">
-                                    <note pname="g" oct="5" dur="8" />
+                                    <note dur="8" oct="5" pname="g" />
                                  </bTrem>
                               </tuplet>
                            </beam>

--- a/_tests/rest/rest-012.mei
+++ b/_tests/rest/rest-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-013.mei
+++ b/_tests/rest/rest-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-015.mei
+++ b/_tests/rest/rest-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-016.mei
+++ b/_tests/rest/rest-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -79,7 +79,7 @@
                         </staffDef>
                      </staffGrp>
                   </scoreDef>
-                     <measure metcon="false">
+                  <measure metcon="false">
                      <staff n="1">
                         <layer n="1">
                            <note xml:id="ex_1297524978" dur="2" oct="5" pname="f" stem.dir="up" />

--- a/_tests/rest/rest-017.mei
+++ b/_tests/rest/rest-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/rest/rest-019.mei
+++ b/_tests/rest/rest-019.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -104,168 +104,168 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
                         </layer>
                         <layer n="2">
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
                         </layer>
                         <layer n="2">
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
                         </layer>
                         <layer n="2">
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
                         </layer>
                         <layer n="2">
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
-                           <rest dur="32" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
+                           <rest dur.ges="4" dur="32" />
                         </layer>
                         <layer n="2">
-                           <rest dur="32" dur.ges="4" />
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="32" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
-                           <rest dur="16" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
+                           <rest dur.ges="4" dur="16" />
                         </layer>
                         <layer n="2">
-                           <rest dur="64" dur.ges="4" />
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="64" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
-                           <rest dur="8" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
+                           <rest dur.ges="4" dur="8" />
                         </layer>
                         <layer n="2">
-                           <rest dur="128" dur.ges="4" />
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="128" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <rest dur="1" dur.ges="4" />
-                           <rest dur="2" dur.ges="4" />
-                           <rest dur="4" dur.ges="4" />
+                           <rest dur.ges="4" dur="1" />
+                           <rest dur.ges="4" dur="2" />
+                           <rest dur.ges="4" dur="4" />
                         </layer>
                         <layer n="2">
-                           <rest dur="256" dur.ges="4" />
-                           <rest dur="512" dur.ges="4" />
-                           <rest dur="1024" dur.ges="4" />
+                           <rest dur.ges="4" dur="256" />
+                           <rest dur.ges="4" dur="512" />
+                           <rest dur.ges="4" dur="1024" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/rest/rest-020.mei
+++ b/_tests/rest/rest-020.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -12,7 +12,7 @@
                <persName role="encoder">Klaus Rettinghaus</persName>
                <persName role="editor">Laurent Pugin</persName>
             </respStmt>
-            <date isodate="2022-09-16"></date>
+            <date isodate="2022-09-16" />
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>

--- a/_tests/sameas/sameas-001.mei
+++ b/_tests/sameas/sameas-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/sameas/sameas-002.mei
+++ b/_tests/sameas/sameas-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef n="1" key.mode="major" key.pname="f" keysig="1f" meter.count="4" meter.unit="4" meter.sym="common">
-                  <staffGrp symbol="bracket" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="bracket">
                      <staffDef n="4" lines="5" clef.shape="F" clef.line="4" />
                   </staffGrp>
                </scoreDef>

--- a/_tests/score/score-001.mei
+++ b/_tests/score/score-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-002.mei
+++ b/_tests/score/score-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,19 +31,19 @@
             <score>
                <scoreDef>
                   <staffGrp symbol="bracket">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="1s" meter.count="3" meter.unit="4">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1s" meter.count="3" meter.unit="4">
                         <label>Soprano</label>
                         <labelAbbr>S</labelAbbr>
                      </staffDef>
-                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2" key.sig="1s" meter.count="3" meter.unit="4">
+                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2" keysig="1s" meter.count="3" meter.unit="4">
                         <label>Alto</label>
                         <labelAbbr>A</labelAbbr>
                      </staffDef>
-                     <staffDef n="3" lines="5" clef.shape="G" clef.line="2" clef.dis="8" clef.dis.place="below" key.sig="1s" meter.count="3" meter.unit="4">
+                     <staffDef n="3" lines="5" clef.shape="G" clef.line="2" clef.dis="8" clef.dis.place="below" keysig="1s" meter.count="3" meter.unit="4">
                         <label>Tenor</label>
                         <labelAbbr>T</labelAbbr>
                      </staffDef>
-                     <staffDef n="4" lines="5" clef.shape="F" clef.line="4" key.sig="1s" meter.count="3" meter.unit="4">
+                     <staffDef n="4" lines="5" clef.shape="F" clef.line="4" keysig="1s" meter.count="3" meter.unit="4">
                         <label>Bass</label>
                         <labelAbbr>B</labelAbbr>
                      </staffDef>

--- a/_tests/score/score-003.mei
+++ b/_tests/score/score-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -45,7 +45,7 @@
                   </measure>
                   <scoreDef>
                      <staffGrp>
-                        <staffDef n="1" clef.shape="C" clef.line="3" key.sig="3f" />
+                        <staffDef n="1" clef.shape="C" clef.line="3" keysig="3f" />
                      </staffGrp>
                   </scoreDef>
                   <measure right="dbl" n="2">

--- a/_tests/score/score-004.mei
+++ b/_tests/score/score-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -32,8 +32,8 @@
             <score>
                <scoreDef>
                   <staffGrp symbol="brace">
-                     <staffDef n="1" lines="5" clef.shape="F" clef.line="4" key.sig="4s" meter.count="4" meter.unit="4" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="4s" meter.count="4" meter.unit="4" />
+                     <staffDef n="1" lines="5" clef.shape="F" clef.line="4" keysig="4s" meter.count="4" meter.unit="4" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="4s" meter.count="4" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
                <section>
@@ -85,8 +85,8 @@
                            </beam>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Presto agitato</tempo>
-                     <dynam staff="1" tstamp="1.250000">p</dynam>
+                     <tempo staff="1" tstamp="1">Presto agitato</tempo>
+                     <dynam staff="1" tstamp="1.25">p</dynam>
                   </measure>
                   <measure n="2">
                      <staff n="1">

--- a/_tests/score/score-005.mei
+++ b/_tests/score/score-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-006.mei
+++ b/_tests/score/score-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-007.mei
+++ b/_tests/score/score-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-008.mei
+++ b/_tests/score/score-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-009.mei
+++ b/_tests/score/score-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-010.mei
+++ b/_tests/score/score-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/score/score-012.mei
+++ b/_tests/score/score-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/section/section-001.mei
+++ b/_tests/section/section-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -9,7 +9,7 @@
             <respStmt>
                <persName role="editor">Laurent Pugin</persName>
                <persName role="encoder">uzumaki
-                  <ref target="https://musescore.com/user/34386"/>   
+                  <ref target="https://musescore.com/user/34386" />
                </persName>
                <persName role="composer">Ludwig van Beethoven</persName>
             </respStmt>
@@ -39,7 +39,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffGrp bar.thru="true" symbol="brace" n="1">
+                     <staffGrp n="1" bar.thru="true" symbol="brace">
                         <label>Thema</label>
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                         <staffDef n="1" lines="5" ppq="24">
@@ -71,7 +71,7 @@
                               <rest dur="4" />
                            </layer>
                         </staff>
-                        <tempo place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="96">Andante con moto</tempo>
+                        <tempo place="above" staff="1" tstamp="1" xml:lang="it" midi.bpm="96">Andante con moto</tempo>
                         <slur startid="#note-0000001690404838" endid="#note-0000000549937366" />
                      </measure>
                      <measure n="2">
@@ -148,10 +148,10 @@
                      <scoreDef>
                         <staffGrp>
                            <staffGrp n="1">
+                              <grpSym symbol="brace" />
                               <label>Var I</label>
                               <staffDef n="1" lines="5" />
                               <staffDef n="2" lines="5" />
-                              <grpSym symbol="brace" />
                            </staffGrp>
                         </staffGrp>
                      </scoreDef>
@@ -228,7 +228,7 @@
                               <beam>
                                  <tuplet num="3" numbase="2" bracket.visible="false">
                                     <note dur="8" oct="4" pname="b" stem.dir="up">
-                                       <accid accid="f"/>
+                                       <accid accid="f" />
                                     </note>
                                     <note dur="8" oct="4" pname="a" stem.dir="up" />
                                     <note dur="8" oct="4" pname="g" stem.dir="up" />
@@ -300,10 +300,10 @@
                         <meterSig sym="cut" />
                         <staffGrp>
                            <staffGrp n="1">
+                              <grpSym symbol="brace" />
                               <label>Var II</label>
                               <staffDef n="1" lines="5" />
                               <staffDef n="2" lines="5" />
-                              <grpSym symbol="brace" />
                            </staffGrp>
                         </staffGrp>
                      </scoreDef>
@@ -380,7 +380,7 @@
                            </layer>
                         </staff>
                      </measure>
-                     <sb/>
+                     <sb />
                      <measure right="end" n="36">
                         <staff n="1">
                            <layer n="1">
@@ -410,14 +410,14 @@
                   </section>
                   <section restart="true" label="var-III">
                      <scoreDef>
-                        <keySig sig="4f"/>
-                        <meterSig sym="common"/>
+                        <keySig sig="4f" />
+                        <meterSig sym="common" />
                         <staffGrp>
                            <staffGrp n="1">
+                              <grpSym symbol="brace" />
                               <label>Var III</label>
                               <staffDef n="1" lines="5" />
                               <staffDef n="2" lines="5" />
-                              <grpSym symbol="brace" />
                            </staffGrp>
                         </staffGrp>
                      </scoreDef>
@@ -467,7 +467,7 @@
                            </layer>
                         </staff>
                         <slur startid="#note-0000000421316471" endid="#note-0000001757179710" />
-                        <dynam place="below" staff="2" tstamp="1.000000" vgrp="200">sempre p e ligato</dynam>
+                        <dynam place="below" staff="2" tstamp="1" vgrp="200">sempre p e ligato</dynam>
                         <slur startid="#note-0000000543968398" endid="#note-0000001817620221" />
                      </measure>
                      <measure n="39">
@@ -529,13 +529,13 @@
                   <sb />
                   <section restart="true" label="var-IV">
                      <scoreDef>
-                        <keySig sig="1f" sig.showchange="true" />
+                        <keySig sig="1f" cancelaccid="before" />
                         <staffGrp>
                            <staffGrp n="1">
+                              <grpSym symbol="brace" />
                               <label>Var IV</label>
                               <staffDef n="1" lines="5" />
                               <staffDef n="2" lines="5" />
-                              <grpSym symbol="brace" />
                            </staffGrp>
                         </staffGrp>
                      </scoreDef>
@@ -553,7 +553,7 @@
                               <rest dur="4" />
                            </layer>
                         </staff>
-                        <dynam place="below" staff="1" tstamp="1.000000" val="96">f</dynam>
+                        <dynam place="below" staff="1" tstamp="1" val="96">f</dynam>
                      </measure>
                      <measure n="51">
                         <staff n="1">

--- a/_tests/section/section-002.mei
+++ b/_tests/section/section-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/section/section-003.mei
+++ b/_tests/section/section-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,7 +36,7 @@
       <body>
          <mdiv>
             <score>
-               <scoreDef midi.bpm="400.000000">
+               <scoreDef midi.bpm="400">
                   <staffGrp>
                      <staffDef n="1" lines="5">
                         <clef shape="G" line="2" />

--- a/_tests/slur/slur-001.mei
+++ b/_tests/slur/slur-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-002.mei
+++ b/_tests/slur/slur-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -49,7 +49,7 @@
                            <rest dur="4" />
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1" tstamp="1.000000">p</dynam>
+                     <dynam place="below" staff="1" tstamp="1">p</dynam>
                      <slur staff="1" startid="#note-L12F3" endid="#note-L17F3" />
                   </measure>
                   <measure n="1">
@@ -113,7 +113,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L19F3" endid="#note-L25F3" />
-                     <dynam staff="2" tstamp="1.500000">p</dynam>
+                     <dynam staff="2" tstamp="1.5">p</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/slur/slur-003.mei
+++ b/_tests/slur/slur-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -46,7 +46,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-000000180893861" endid="#note-000000090536214" />
-                     <dir place="above" staff="1" tstamp="2.000000">a tempo</dir>
+                     <dir place="above" staff="1" tstamp="2">a tempo</dir>
                      <slur staff="1" startid="#note-000000034369893" endid="#note-000000110366772" />
                      <fermata startid="#note-000000180893861" place="above" />
                   </measure>

--- a/_tests/slur/slur-004.mei
+++ b/_tests/slur/slur-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-005.mei
+++ b/_tests/slur/slur-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-006.mei
+++ b/_tests/slur/slur-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -62,10 +62,10 @@
                            <note dots="1" dur="2" oct="4" pname="d" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">ten.</dir>
-                     <dynam staff="1" tstamp="2.500000">pp</dynam>
+                     <dir place="above" staff="1" tstamp="1">ten.</dir>
+                     <dynam staff="1" tstamp="2.5">pp</dynam>
                      <slur staff="1" startid="#chord-000000206849720" endid="#chord-000000028066101" />
-                     <dynam staff="1" tstamp="1.000000">sf</dynam>
+                     <dynam staff="1" tstamp="1">sf</dynam>
                      <staff n="2">
                         <!-- kern: **kern  *clefF4  *M3/4  *^  4r  8r  (8cnL  8B  8AJ)  *v  = -->
                         <layer n="1">
@@ -118,7 +118,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <dir place="above" staff="2" tstamp="1.000000">riten.</dir>
+                     <dir place="above" staff="2" tstamp="1">riten.</dir>
                      <slur staff="2" startid="#note-000000051672979" endid="#note-000000120866214" />
                      <slur staff="2" startid="#note-000000211839453" endid="#note-000000072548209" />
                   </measure>

--- a/_tests/slur/slur-007.mei
+++ b/_tests/slur/slur-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-008.mei
+++ b/_tests/slur/slur-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-009.mei
+++ b/_tests/slur/slur-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -37,8 +37,8 @@
                            <note xml:id="n2" dur="2" oct="4" pname="c" />
                         </layer>
                      </staff>
-                     <slur staff="1" tstamp="0.000000" endid="#n2" curvedir="above" />
-                     <slur staff="1" startid="#n1" tstamp2="1m+5.0000" />
+                     <slur staff="1" tstamp="0" endid="#n2" curvedir="above" />
+                     <slur staff="1" startid="#n1" tstamp2="1m+5" />
                   </measure>
                   <measure n="2">
                      <staff n="1">

--- a/_tests/slur/slur-010.mei
+++ b/_tests/slur/slur-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -48,7 +48,7 @@
                            <note xml:id="m0-s1-note6" dur="8" oct="4" pname="e" />
                         </layer>
                      </staff>
-                     <slur startid="#m0-s1-note4" endid="#m0-s1-note6" color="orange" curvedir="above" />
+                     <slur color="orange" startid="#m0-s1-note4" endid="#m0-s1-note6" curvedir="above" />
                   </measure>
                   <measure n="1">
                      <staff n="1">
@@ -57,7 +57,7 @@
                            <note xml:id="m1-s1-note2" dur="16" oct="4" pname="g" />
                         </layer>
                      </staff>
-                     <tie startid="#m1-s1-note1" endid="#m1-s1-note2" color="orange" />
+                     <tie color="orange" startid="#m1-s1-note1" endid="#m1-s1-note2" />
                   </measure>
                </section>
             </score>

--- a/_tests/slur/slur-011.mei
+++ b/_tests/slur/slur-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -58,7 +58,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L3F2" endid="#note-L4F2" curvedir="above" />
-                     <dir place="above" staff="1" tstamp="1.000000">curvedir="above"</dir>
+                     <dir place="above" staff="1" tstamp="1">curvedir="above"</dir>
                   </measure>
                   <measure n="3">
                      <staff n="1">
@@ -68,7 +68,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-L3F3" endid="#note-L4F3" />
-                     <dir place="above" staff="1" tstamp="1.000000">stem.dir="down"</dir>
+                     <dir place="above" staff="1" tstamp="1">stem.dir="down"</dir>
                   </measure>
                   <measure n="4">
                      <staff n="1">
@@ -99,7 +99,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#chord-L3F5" endid="#chord-L4F5" curvedir="above" />
-                     <dir place="above" staff="1" tstamp="1.000000">curvedir="above"</dir>
+                     <dir place="above" staff="1" tstamp="1">curvedir="above"</dir>
                   </measure>
                   <measure n="6">
                      <staff n="1">
@@ -115,7 +115,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#chord-L3F6" endid="#chord-L4F6" />
-                     <dir place="above" staff="1" tstamp="1.000000">stem.dir="down"</dir>
+                     <dir place="above" staff="1" tstamp="1">stem.dir="down"</dir>
                   </measure>
                </section>
             </score>

--- a/_tests/slur/slur-012.mei
+++ b/_tests/slur/slur-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-013.mei
+++ b/_tests/slur/slur-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -54,7 +54,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">slur attached to chord</rend>
                      </dir>
                      <slur staff="1" startid="#note-L5F1" endid="#chord-L6F1" curvedir="above" />
@@ -81,7 +81,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">slur attached to G note</rend>
                      </dir>
                      <slur staff="1" startid="#note-L12F1" endid="#note-L14F1S2" curvedir="above" />
@@ -108,7 +108,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">slur attached to A note</rend>
                      </dir>
                      <slur staff="1" startid="#note-L21F1" endid="#note-L23F1S1" curvedir="above" />
@@ -135,7 +135,7 @@
                            <note xml:id="note-L31F1" dur="2" oct="5" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">slur attached from chord</rend>
                      </dir>
                      <slur staff="1" startid="#chord-L30F1" endid="#note-L31F1" curvedir="above" />
@@ -162,7 +162,7 @@
                            <note xml:id="note-L39F1" dur="2" oct="5" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">slur attached from G note</rend>
                      </dir>
                      <slur staff="1" startid="#note-L38F1S2" endid="#note-L39F1" curvedir="above" />
@@ -189,7 +189,7 @@
                            <note xml:id="note-L48F1" dur="2" oct="5" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">
+                     <dir place="above" staff="1" tstamp="1">
                         <rend fontstyle="normal">slur attached from A note</rend>
                      </dir>
                      <slur staff="1" startid="#note-L47F1S1" endid="#note-L48F1" curvedir="above" />

--- a/_tests/slur/slur-014.mei
+++ b/_tests/slur/slur-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -92,7 +92,7 @@
                         </layer>
                      </staff>
                      <slur startid="#ex_0713646956" endid="#ex_1525030897" curvedir="above" />
-                     <hairpin staff="3" tstamp="2.000000" tstamp2="0m+4.5000" form="cres" place="above" vgrp="254" />
+                     <hairpin staff="3" tstamp="2" tstamp2="0m+4.5" form="cres" place="above" vgrp="254" />
                      <slur startid="#ex_0945791345" endid="#ex_2110968671" curvedir="below" />
                   </measure>
                </section>

--- a/_tests/slur/slur-015.mei
+++ b/_tests/slur/slur-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-016.mei
+++ b/_tests/slur/slur-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -41,7 +41,7 @@
                            <note dur="4" oct="4" pname="c" stem.dir="up" accid.ges="n" />
                         </layer>
                      </staff>
-                     <slur staff="1" tstamp="0.0" tstamp2="1m+3.0" />
+                     <slur staff="1" tstamp="0" tstamp2="1m+3" />
                   </measure>
                   <measure n="1">
                      <staff n="1">

--- a/_tests/slur/slur-017.mei
+++ b/_tests/slur/slur-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -86,7 +86,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1" tstamp="1.000000">f</dynam>
+                     <dynam place="below" staff="1" tstamp="1">f</dynam>
                      <slur startid="#note-0000002081589455" endid="#note-0000002140675496" />
                      <tie startid="#note-0000000742682538" endid="#note-0000001881443311" />
                      <tie startid="#note-0000000066447736" endid="#note-0000000429164090" />

--- a/_tests/slur/slur-018.mei
+++ b/_tests/slur/slur-018.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,6 +39,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <staffDef n="1" lines="5" ppq="4">
                            <clef shape="G" line="2" />
                            <keySig sig="2f" />
@@ -49,7 +50,6 @@
                            <keySig sig="2f" />
                            <meterSig count="4" sym="common" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
@@ -59,7 +59,7 @@
                      <staff n="1">
                         <layer n="1">
                            <note dots="1" dur.ppq="12" dur="2" oct="4" pname="g" stem.dir="up" />
-                           <note xml:id="note-0006-11260-10990-1" dots="1" dur.ppq="12" dur="2" oct="5" pname="g" stem.dir="up" />
+                           <note dots="1" dur.ppq="12" dur="2" oct="5" pname="g" stem.dir="up" />
                         </layer>
                         <layer n="2">
                            <rest dur.ppq="4" dur="4" />

--- a/_tests/slur/slur-019.mei
+++ b/_tests/slur/slur-019.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-020.mei
+++ b/_tests/slur/slur-020.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,6 +39,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <staffDef n="1" lines="5" ppq="4">
                            <clef shape="G" line="2" />
                            <keySig sig="2f" />
@@ -49,7 +50,6 @@
                            <keySig sig="2f" />
                            <meterSig count="4" sym="common" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
@@ -107,10 +107,10 @@
                         </layer>
                      </staff>
                      <slur startid="#note-0008-10250-12600-2" endid="#note-0008-10350-12560-2" curvedir="above" />
-                     <pedal staff="2" tstamp="1.000000" dir="down" place="below" vgrp="80" />
-                     <pedal staff="2" tstamp="2.900000" dir="up" place="below" vgrp="80" />
-                     <pedal staff="2" tstamp="4.000000" dir="down" place="below" vgrp="80" />
-                     <pedal staff="2" tstamp="5.900000" dir="up" place="below" vgrp="80" />
+                     <pedal staff="2" tstamp="1" dir="down" place="below" vgrp="80" />
+                     <pedal staff="2" tstamp="2.9" dir="up" place="below" vgrp="80" />
+                     <pedal staff="2" tstamp="4" dir="down" place="below" vgrp="80" />
+                     <pedal staff="2" tstamp="5.9" dir="up" place="below" vgrp="80" />
                   </measure>
                </section>
             </score>

--- a/_tests/slur/slur-021.mei
+++ b/_tests/slur/slur-021.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/slur/slur-022.mei
+++ b/_tests/slur/slur-022.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,6 +39,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
@@ -52,7 +53,6 @@
                            <keySig sig="0" />
                            <meterSig count="4" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
@@ -96,12 +96,12 @@
                            </beam>
                         </layer>
                         <layer n="5">
-                           <note xml:id="n8uv6q1" dur.ppq="16" dur="1" oct="3" pname="b" accid="f" />
+                           <note dur.ppq="16" dur="1" oct="3" pname="b" accid="f" />
                         </layer>
                      </staff>
                      <slur startid="#ntp3tut" endid="#ngxeh57" curvedir="above" />
                      <slur startid="#nk08i18" endid="#nub8m7a" curvedir="above" />
-                     <hairpin staff="1" tstamp="1.750000" tstamp2="0m+3.0000" form="cres" place="below" vgrp="86" />
+                     <hairpin staff="1" tstamp="1.75" tstamp2="0m+3" form="cres" place="below" vgrp="86" />
                      <tie startid="#nusapwi" endid="#nwzlx40" />
                   </measure>
                </section>

--- a/_tests/slur/slur-023.mei
+++ b/_tests/slur/slur-023.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -40,12 +40,12 @@
                         <staffDef n="1" lines="5">
                            <clef shape="G" line="2" visible="false" />
                            <keySig sig="0" visible="false" />
-                           <meterSig count="6" unit="8" form="invis" />
+                           <meterSig count="6" unit="8" visible="false" />
                         </staffDef>
                         <staffDef n="2" lines="5">
                            <clef shape="F" line="4" visible="false" />
                            <keySig sig="0" visible="false" />
-                           <meterSig count="6" unit="8" form="invis" />
+                           <meterSig count="6" unit="8" visible="false" />
                         </staffDef>
                      </staffGrp>
                   </staffGrp>
@@ -92,9 +92,9 @@
                               <note dur="8" oct="3" pname="b" />
                            </beam>
                            <beam staff="1">
-                              <note dur="8" oct="4" pname="e" staff="1" />
-                              <note dur="8" oct="4" pname="g" staff="1" />
-                              <note xml:id="nwv4568d" dur="8" oct="4" pname="b" staff="1" />
+                              <note dur="8" staff="1" oct="4" pname="e" />
+                              <note dur="8" staff="1" oct="4" pname="g" />
+                              <note xml:id="nwv4568d" dur="8" staff="1" oct="4" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -104,9 +104,9 @@
                      <staff n="1">
                         <layer n="1">
                            <beam>
-                              <note xml:id="nsh8ep2f" dur="8" oct="3" pname="e" staff="2" />
-                              <note dur="8" oct="3" pname="g" staff="2" />
-                              <note dur="8" oct="3" pname="b" staff="2" />
+                              <note xml:id="nsh8ep2f" dur="8" staff="2" oct="3" pname="e" />
+                              <note dur="8" staff="2" oct="3" pname="g" />
+                              <note dur="8" staff="2" oct="3" pname="b" />
                            </beam>
                            <beam staff="1">
                               <note dur="8" oct="4" pname="e" />

--- a/_tests/space/space-001.mei
+++ b/_tests/space/space-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -30,7 +30,7 @@
          <mdiv>
             <score>
                <scoreDef keysig="3s" meter.count="4" meter.unit="4">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="3s" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="3s" />
                   </staffGrp>

--- a/_tests/space/space-002.mei
+++ b/_tests/space/space-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-001.mei
+++ b/_tests/stem/stem-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -35,11 +35,11 @@
                   <measure right="end" n="0">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="4" oct="4" pname="c" stem.len="0.000000" accid.ges="n" />
-                           <note dur="4" oct="4" pname="d" stem.len="1.000000" accid.ges="n" />
-                           <note dur="4" oct="4" pname="e" stem.len="3.000000" accid.ges="n" />
-                           <note dur="4" oct="4" pname="f" stem.len="5.000000" accid.ges="n" />
-                           <note dur="4" oct="4" pname="g" stem.len="7.000000" accid.ges="n" />
+                           <note dur="4" oct="4" pname="c" stem.len="0" accid.ges="n" />
+                           <note dur="4" oct="4" pname="d" stem.len="1" accid.ges="n" />
+                           <note dur="4" oct="4" pname="e" stem.len="3" accid.ges="n" />
+                           <note dur="4" oct="4" pname="f" stem.len="5" accid.ges="n" />
+                           <note dur="4" oct="4" pname="g" stem.len="7" accid.ges="n" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/stem/stem-002.mei
+++ b/_tests/stem/stem-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-003.mei
+++ b/_tests/stem/stem-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-004.mei
+++ b/_tests/stem/stem-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-005.mei
+++ b/_tests/stem/stem-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-006.mei
+++ b/_tests/stem/stem-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-007.mei
+++ b/_tests/stem/stem-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-008.mei
+++ b/_tests/stem/stem-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,7 +36,7 @@
                      <staff n="1">
                         <layer n="1">
                            <note dur="4" oct="4" pname="f" color="blue" accid.ges="n" />
-                           <note dur="4" oct="4" pname="f" color="blue" stem.len="0.000000" accid.ges="n" />
+                           <note dur="4" oct="4" pname="f" color="blue" stem.len="0" accid.ges="n" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/stem/stem-009.mei
+++ b/_tests/stem/stem-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -35,15 +35,15 @@
                   <measure n="0">
                      <staff n="1">
                         <layer n="1">
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="g" cue="true" accid.ges="s" />
                               <note oct="3" pname="b" cue="true" accid.ges="n" />
                            </chord>
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="a" cue="true" accid.ges="n" />
                               <note oct="4" pname="e" cue="true" accid.ges="n" />
                            </chord>
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="a" cue="true" accid.ges="n" />
                               <note oct="4" pname="c" cue="true" accid.ges="s" />
                            </chord>
@@ -54,7 +54,7 @@
                            <note dur="4" oct="3" pname="f" accid.ges="s" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="1" tstamp="2.000000">
+                     <harm place="below" staff="1" tstamp="2">
                         <fb>
                            <f>6</f>
                         </fb>
@@ -63,15 +63,15 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <note dur="2" oct="3" pname="f" cue="true" stem.len="0.000000" accid.ges="s" />
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <note dur="2" oct="3" pname="f" cue="true" stem.len="0" accid.ges="s" />
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="b" cue="true" accid.ges="n" />
                               <note oct="4" pname="e" cue="true" accid.ges="n" />
                            </chord>
                         </layer>
                         <layer n="2">
-                           <note dur="4" oct="4" pname="c" cue="true" stem.len="0.000000" accid.ges="s" />
-                           <note dur="4" oct="3" pname="b" cue="true" stem.len="0.000000" accid.ges="n" />
+                           <note dur="4" oct="4" pname="c" cue="true" stem.len="0" accid.ges="s" />
+                           <note dur="4" oct="3" pname="b" cue="true" stem.len="0" accid.ges="n" />
                            <note dur="4" oct="3" pname="g" accid="n" />
                         </layer>
                         <layer n="3">
@@ -79,12 +79,12 @@
                            <space dur="4" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="1" tstamp="1.000000">
+                     <harm place="below" staff="1" tstamp="1">
                         <fb>
                            <f>76</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="3.000000">
+                     <harm place="below" staff="1" tstamp="3">
                         <fb>
                            <f>6</f>
                         </fb>
@@ -93,12 +93,12 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="a" cue="true" accid="s" />
                               <note oct="4" pname="c" cue="true" accid.ges="s" />
                               <note oct="4" pname="f" cue="true" accid.ges="s" />
                            </chord>
-                           <chord dur="2" cue="true" stem.len="0.000000">
+                           <chord dur="2" cue="true" stem.len="0">
                               <note oct="3" pname="f" cue="true" accid.ges="s" />
                               <note oct="3" pname="b" cue="true" accid.ges="n" />
                               <note oct="4" pname="d" cue="true" accid.ges="n" />
@@ -114,29 +114,29 @@
                            </beam>
                         </layer>
                      </staff>
-                     <harm place="below" staff="1" tstamp="1.000000">
+                     <harm place="below" staff="1" tstamp="1">
                         <fb>
                            <f>♯</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="2.000000">
+                     <harm place="below" staff="1" tstamp="2">
                         <fb>
                            <f>7</f>
                            <f>5</f>
                            <f>2</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="2.500000">
+                     <harm place="below" staff="1" tstamp="2.5">
                         <fb>
                            <f>_</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="3.000000">
+                     <harm place="below" staff="1" tstamp="3">
                         <fb>
                            <f>_</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="3.500000">
+                     <harm place="below" staff="1" tstamp="3.5">
                         <fb>
                            <f>_</f>
                         </fb>
@@ -145,7 +145,7 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <chord dots="1" dur="2" cue="true" stem.len="0.000000">
+                           <chord dots="1" dur="2" cue="true" stem.len="0">
                               <note oct="3" pname="a" cue="true" accid="s" />
                               <note oct="4" pname="c" cue="true" accid.ges="s" />
                               <note oct="4" pname="f" cue="true" accid.ges="s" />
@@ -157,17 +157,17 @@
                            <note dur="4" oct="2" pname="g" accid.ges="s" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="1" tstamp="1.000000">
+                     <harm place="below" staff="1" tstamp="1">
                         <fb>
                            <f>♯</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="2.000000">
+                     <harm place="below" staff="1" tstamp="2">
                         <fb>
                            <f>_</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="3.000000">
+                     <harm place="below" staff="1" tstamp="3">
                         <fb>
                            <f>_</f>
                         </fb>
@@ -176,15 +176,15 @@
                   <measure>
                      <staff n="1">
                         <layer n="1">
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="c" cue="true" accid.ges="s" />
                               <note oct="3" pname="f" cue="true" accid.ges="s" />
                            </chord>
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="e" cue="true" accid.ges="n" />
                               <note oct="3" pname="g" cue="true" accid.ges="s" />
                            </chord>
-                           <chord dur="4" cue="true" stem.len="0.000000">
+                           <chord dur="4" cue="true" stem.len="0">
                               <note oct="3" pname="e" cue="true" accid.ges="n" />
                               <note oct="3" pname="f" cue="true" accid.ges="s" />
                               <note oct="3" pname="a" cue="true" accid="s" />
@@ -196,18 +196,18 @@
                            <note dur="4" oct="3" pname="c" accid.ges="s" />
                         </layer>
                      </staff>
-                     <harm place="below" staff="1" tstamp="1.000000">
+                     <harm place="below" staff="1" tstamp="1">
                         <fb>
                            <f>6</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="2.000000">
+                     <harm place="below" staff="1" tstamp="2">
                         <fb>
                            <f>6</f>
                            <f>4</f>
                         </fb>
                      </harm>
-                     <harm place="below" staff="1" tstamp="3.000000">
+                     <harm place="below" staff="1" tstamp="3">
                         <fb>
                            <f>6♯</f>
                            <f>4</f>

--- a/_tests/stem/stem-010.mei
+++ b/_tests/stem/stem-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-011.mei
+++ b/_tests/stem/stem-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-012.mei
+++ b/_tests/stem/stem-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-013.mei
+++ b/_tests/stem/stem-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -46,15 +46,15 @@
                         <layer n="1">
                            <chord dur="4">
                               <note oct="4" pname="g" />
-                              <note oct="3" pname="g" staff="2"/>
+                              <note staff="2" oct="3" pname="g" />
                            </chord>
                            <chord dur="4">
                               <note oct="4" pname="g" />
-                              <note oct="4" pname="c" staff="2"/>
+                              <note staff="2" oct="4" pname="c" />
                            </chord>
                            <chord dur="4">
                               <note oct="4" pname="g" />
-                              <note oct="4" pname="e" staff="2"/>
+                              <note staff="2" oct="4" pname="e" />
                            </chord>
                         </layer>
                      </staff>

--- a/_tests/stem/stem-014.mei
+++ b/_tests/stem/stem-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-015.mei
+++ b/_tests/stem/stem-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/stem/stem-016.mei
+++ b/_tests/stem/stem-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/symbol/symbol-001.mei
+++ b/_tests/symbol/symbol-001.mei
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Symbol mixed with text or within editorial markup</title>
          </titleStmt>
          <pubStmt>
-            <date isodate="2022-09-16"></date>
+            <date isodate="2022-09-16" />
          </pubStmt>
          <notesStmt>
             <annot>Symbol can be mixed with text or place within editorial markup.</annot>

--- a/_tests/symbol/symbol-002.mei
+++ b/_tests/symbol/symbol-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -55,14 +55,14 @@
                            <note dur="4" oct="4" pname="e" />
                         </layer>
                      </staff>
-                     <dir place="above" tstamp="1.000000">
+                     <dir place="above" tstamp="1">
                         <symbol glyph.auth="smufl" glyph.num="U+E530" />
                         <symbol color="crimson" glyph.auth="smufl" glyph.name="dynamicForte" />
                      </dir>
-                     <dir place="above" tstamp="2.000000">
+                     <dir place="above" tstamp="2">
                         <symbol glyph.auth="smufl" glyph.num="U+E7E4" />
                      </dir>
-                     <dir place="above" tstamp="3.000000">
+                     <dir place="above" tstamp="3">
                         <symbol color="darkcyan" glyph.auth="smufl" glyph.num="U+E7E4" fontsize="x-large" />
                      </dir>
                   </measure>

--- a/_tests/symboldef/symboldef-001.mei
+++ b/_tests/symboldef/symboldef-001.mei
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
             <title>User defined symbols</title>
          </titleStmt>
          <pubStmt>
-            <date isodate="2022-12-20"/>
+            <date isodate="2022-12-20" />
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>
@@ -90,16 +90,16 @@
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <mRest xml:id="mrest1"/>
+                           <mRest xml:id="mrest1" />
                         </layer>
                      </staff>
                      <staff n="3">
                         <layer n="1">
-                           <mRest/>
+                           <mRest />
                         </layer>
                      </staff>
-                     <fermata staff="2 3" startid="#mrest1" altsym="#custom-fermata" enclose="brack" />
-                     <caesura staff="1 2" tstamp="4.3" altsym="#smile" />
+                     <fermata altsym="#custom-fermata" staff="2 3" startid="#mrest1" enclose="brack" />
+                     <caesura altsym="#smile" staff="1 2" tstamp="4.3" />
                   </measure>
                </section>
             </score>

--- a/_tests/symboldef/symboldef-002.mei
+++ b/_tests/symboldef/symboldef-002.mei
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
             <title>User defined symbols</title>
          </titleStmt>
          <pubStmt>
-            <date isodate="2022-12-20"/>
+            <date isodate="2022-12-20" />
          </pubStmt>
          <seriesStmt>
             <title>Verovio test suite</title>

--- a/_tests/tab/tab-002.mei
+++ b/_tests/tab/tab-002.mei
@@ -1,191 +1,192 @@
-<?xml version="1.0" standalone="no"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>German lute tablature example</title>
-            </titleStmt>
-            <pubStmt>
-                <respStmt>
-                    <persName role="encoder">Olja Janjuš</persName>
-                </respStmt>
-                <date isodate="2024-12-04" />
-            </pubStmt>
-            <notesStmt>
-                <annot>Lute tablature rendering</annot>
-            </notesStmt>
-            <sourceDesc>
-                <source>
-                    <bibl>
-                        <title>Elslein liebes Elslein.</title>
-                        <title type="main">Ain schone kunstliche Underweisung</title>
-                        <author>Hans Judenkünig</author>
-                        <date>1523</date>
-                        <locus>22v</locus>
-                    </bibl>
-                </source>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application isodate="2023-12-15" version="1.4.7">
-                    <name>luteconv</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-        <workList>
-            <work>
-                <title>Elslein liebes Elslein.</title>
-                <composer>Hans Judenkünig</composer>
-            </work>
-        </workList>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv n="1">
-                <score>
-                    <scoreDef>
-                        <staffGrp>
-                            <staffDef n="1" lines="3" notationtype="tab.lute.german"
-                                tab.align="bottom">
-                                <mensur sign="C" num="3" />
-                                <tuning>
-                                    <course n="1" pname="a" oct="4" />
-                                    <course n="2" pname="e" oct="4" />
-                                    <course n="3" pname="b" oct="3" />
-                                    <course n="4" pname="g" oct="3" />
-                                    <course n="5" pname="d" oct="3" />
-                                    <course n="6" pname="a" oct="2" />
-                                </tuning>
-                            </staffDef>
-                        </staffGrp>
-                    </scoreDef>
-                    <section n="1">
-                        <measure n="1">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym tab.line="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <tabDurSym tab.line="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="0" />
-                                        <note tab.course="4" tab.fret="2" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="2">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="0" />
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="2" tab.fret="3" xml:id="id0" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="2" xml:id="id1" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="0" xml:id="id2" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id0" />
-                            <fing playingHand="right" playingFinger="1" startid="#id1" />
-                            <fing playingHand="right" playingFinger="1" startid="#id2" />
-                        </measure>
-                        <measure n="3">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="2" />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="2" xml:id="id3" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="0" xml:id="id4" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="0" />
-                                        <note tab.course="2" tab.fret="2" />
-                                        <note tab.course="3" tab.fret="3" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id3" />
-                            <fing playingHand="right" playingFinger="1" startid="#id4" />
-                        </measure>
-                        <measure n="4">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="2" />
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="2" />
-                                        <note tab.course="2" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym tab.line="3" />
-                                        <note tab.course="1" tab.fret="4" xml:id="id5" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="5" />
-                                        <note tab.course="2" tab.fret="2" />
-                                        <note tab.course="3" tab.fret="0" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id5" />
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>German lute tablature example</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="encoder">Olja Janjuš</persName>
+            </respStmt>
+            <date isodate="2024-12-04" />
+         </pubStmt>
+         <notesStmt>
+            <annot>Lute tablature rendering</annot>
+         </notesStmt>
+         <sourceDesc>
+            <source>
+               <bibl>
+                  <title>Elslein liebes Elslein.</title>
+                  <title type="main">Ain schone kunstliche Underweisung</title>
+                  <author>Hans Judenkünig</author>
+                  <date>1523</date>
+                  <locus>22v</locus>
+               </bibl>
+            </source>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application isodate="2023-12-15" version="1.4.7">
+               <name>luteconv</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+      <workList>
+         <work>
+            <title>Elslein liebes Elslein.</title>
+            <composer>Hans Judenkünig</composer>
+         </work>
+      </workList>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv n="1">
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" notationtype="tab.lute.german" lines="3" tab.align="bottom">
+                        <mensur num="3" sign="C" />
+                        <tuning>
+                           <course n="1" oct="4" pname="a" />
+                           <course n="2" oct="4" pname="e" />
+                           <course n="3" oct="3" pname="b" />
+                           <course n="4" oct="3" pname="g" />
+                           <course n="5" oct="3" pname="d" />
+                           <course n="6" oct="2" pname="a" />
+                        </tuning>
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section n="1">
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym tab.line="3" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <tabDurSym tab.line="3" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <tabDurSym tab.line="3" />
+                              <note tab.course="1" tab.fret="0" />
+                              <note tab.course="4" tab.fret="2" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="0" />
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="4" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym tab.line="3" />
+                              <note tab.course="1" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym tab.line="3" />
+                              <note xml:id="id0" tab.course="2" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym tab.line="3" />
+                              <note tab.course="1" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym tab.line="3" />
+                              <note xml:id="id1" tab.course="1" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="3" />
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="4" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym tab.line="3" />
+                              <note xml:id="id2" tab.course="1" tab.fret="0" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id0" playingHand="right" playingFinger="1" />
+                     <fing startid="#id1" playingHand="right" playingFinger="1" />
+                     <fing startid="#id2" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="2" />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym />
+                              <note xml:id="id3" tab.course="3" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym />
+                              <note xml:id="id4" tab.course="2" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="0" />
+                              <note tab.course="2" tab.fret="2" />
+                              <note tab.course="3" tab.fret="3" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id3" playingHand="right" playingFinger="1" />
+                     <fing startid="#id4" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="2" />
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym tab.line="3" />
+                              <note tab.course="1" tab.fret="2" />
+                              <note tab.course="2" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym tab.line="3" />
+                              <note xml:id="id5" tab.course="1" tab.fret="4" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="5" />
+                              <note tab.course="2" tab.fret="2" />
+                              <note tab.course="3" tab.fret="0" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id5" playingHand="right" playingFinger="1" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tab/tab-003.mei
+++ b/_tests/tab/tab-003.mei
@@ -1,226 +1,228 @@
-<?xml version="1.0" standalone="no"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>Italian lute tablature example</title>
-            </titleStmt>
-            <pubStmt>
-                <respStmt>
-                    <persName role="encoder">Olja Janjuš</persName>
-                </respStmt>
-                <date isodate="2024-12-04" />
-            </pubStmt>
-            <notesStmt>
-                <annot>Lute tablature rendering</annot>
-            </notesStmt>
-            <sourceDesc>
-                <source>
-                    <bibl>
-                        <title>Recercar Sexto</title>
-                        <title type="main">Itabulatura de lauto</title>
-                        <composer>Giovanni Maria da Crema</composer>
-                        <arranger>Francesco da Milano</arranger>
-                        <date>1546</date>
-                        <locus>B1v-B2r</locus>
-                    </bibl>
-                </source>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application isodate="2022-09-26" version="1.4.5">
-                    <name>luteconv</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-        <workList>
-            <work>
-                <title>Recercar Sexto</title>
-                <composer>Giovanni Maria da Crema</composer>
-            </work>
-        </workList>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv n="1">
-                <score>
-                    <scoreDef>
-                        <staffGrp>
-                            <staffDef n="1" lines="6" notationtype="tab.lute.italian">
-                                <tuning>
-                                    <course n="1" pname="g" oct="4" />
-                                    <course n="2" pname="d" oct="4" />
-                                    <course n="3" pname="a" oct="3" />
-                                    <course n="4" pname="f" oct="3" />
-                                    <course n="5" pname="c" oct="3" />
-                                    <course n="6" pname="g" oct="2" />
-                                </tuning>
-                            </staffDef>
-                        </staffGrp>
-                    </scoreDef>
-                    <section n="1">
-                        <measure n="19">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="4" tab.fret="2" />
-                                        <note tab.course="5" tab.fret="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="20">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <note tab.course="2" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="2" />
-                                        <note tab.course="5" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="3" tab.fret="0" xml:id="id15" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="0" />
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="6" tab.fret="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="5" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="5" tab.fret="3" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id15" />
-                        </measure>
-                        <measure n="21">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="0" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="2" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="4" tab.fret="2" />
-                                        <note tab.course="5" tab.fret="3" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="22">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <note tab.course="2" tab.fret="0" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="2" tab.fret="2" xml:id="id16" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="2" tab.fret="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="1" tab.fret="0" xml:id="id17" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="2" />
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="1" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="2" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id16" />
-                            <fing playingHand="right" playingFinger="1" startid="#id17" />
-                        </measure>
-                        <measure n="23" metcon="false">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <note tab.course="1" tab.fret="2" />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="5" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="0" xml:id="id18" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="3" tab.fret="1" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id18" />
-                        </measure>
-                        <measure n="25">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="4">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="0" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="4">
-                                        <note tab.course="2" tab.fret="4" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="2" xml:id="id19">
-                                        <note tab.course="1" tab.fret="0" />
-                                        <note tab.course="2" tab.fret="0" />
-                                        <note tab.course="4" tab.fret="2" />
-                                        <note tab.course="6" tab.fret="0" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fermata startid="#id19" />
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Italian lute tablature example</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="encoder">Olja Janjuš</persName>
+            </respStmt>
+            <date isodate="2024-12-04" />
+         </pubStmt>
+         <notesStmt>
+            <annot>Lute tablature rendering</annot>
+         </notesStmt>
+         <sourceDesc>
+            <source>
+               <bibl>
+                  <title>Recercar Sexto</title>
+                  <title type="main">Itabulatura de lauto</title>
+                  <composer>Giovanni Maria da Crema</composer>
+                  <arranger>Francesco da Milano</arranger>
+                  <date>1546</date>
+                  <locus>B1v-B2r</locus>
+               </bibl>
+            </source>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application isodate="2022-09-26" version="1.4.5">
+               <name>luteconv</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+      <workList>
+         <work>
+            <title>Recercar Sexto</title>
+            <composer>Giovanni Maria da Crema</composer>
+         </work>
+      </workList>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv n="1">
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" notationtype="tab.lute.italian" lines="6">
+                        <tuning>
+                           <course n="1" oct="4" pname="g" />
+                           <course n="2" oct="4" pname="d" />
+                           <course n="3" oct="3" pname="a" />
+                           <course n="4" oct="3" pname="f" />
+                           <course n="5" oct="3" pname="c" />
+                           <course n="6" oct="2" pname="g" />
+                        </tuning>
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section n="1">
+                  <measure n="19">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="4" tab.fret="2" />
+                              <note tab.course="5" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="20">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <note tab.course="2" tab.fret="1" />
+                              <note tab.course="4" tab.fret="2" />
+                              <note tab.course="5" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note xml:id="id15" tab.course="3" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="0" />
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="6" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="5" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="5" tab.fret="3" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id15" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure n="21">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="0" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="4" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="2" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="4" tab.fret="2" />
+                              <note tab.course="5" tab.fret="3" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="22">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <note tab.course="2" tab.fret="0" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note xml:id="id16" tab.course="2" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="2" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note xml:id="id17" tab.course="1" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="2" />
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="1" tab.fret="3" />
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="4" tab.fret="2" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id16" playingHand="right" playingFinger="1" />
+                     <fing startid="#id17" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure metcon="false" n="23">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <note tab.course="1" tab.fret="2" />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="5" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note xml:id="id18" tab.course="1" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="3" tab.fret="1" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id18" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure n="25">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="4">
+                              <tabDurSym />
+                              <note tab.course="1" tab.fret="0" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="4">
+                              <note tab.course="2" tab.fret="4" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp xml:id="id19" dur="2">
+                              <note tab.course="1" tab.fret="0" />
+                              <note tab.course="2" tab.fret="0" />
+                              <note tab.course="4" tab.fret="2" />
+                              <note tab.course="6" tab.fret="0" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fermata startid="#id19" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tempo/tempo-001.mei
+++ b/_tests/tempo/tempo-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -47,7 +47,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <tempo midi.bpm="70" staff="1" tstamp="1.000000">Andante con moto <rend fontfam="smufl"></rend> = 70</tempo>
+                     <tempo staff="1" tstamp="1" midi.bpm="70">Andante con moto <rend glyph.auth="smufl"></rend> = 70</tempo>
                      <slur startid="#m0_s2_e1" endid="#m0_s2_e2" />
                   </measure>
                   <measure n="1">

--- a/_tests/tempo/tempo-002.mei
+++ b/_tests/tempo/tempo-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -73,11 +73,11 @@
                            <note dur="1" oct="3" pname="c" />
                         </layer>
                      </staff>
-                     <dynam place="below" staff="1" tstamp="1.100000">p</dynam>
-                     <tempo staff="1" tstamp="1.000000">
+                     <dynam place="below" staff="1" tstamp="1.1">p</dynam>
+                     <tempo staff="1" tstamp="1">
                         <rend fontweight="normal">Modérément animé</rend>
                      </tempo>
-                     <slur staff="1" startid="#d1e116" tstamp2="0m+5.0000" curvedir="below" />
+                     <slur staff="1" startid="#d1e116" tstamp2="0m+5" curvedir="below" />
                   </measure>
                </section>
             </score>

--- a/_tests/tempo/tempo-003.mei
+++ b/_tests/tempo/tempo-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -32,7 +32,7 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="132">
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="1f" meter.count="3" meter.unit="4" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="1f" meter.count="3" meter.unit="4" />
                   </staffGrp>
@@ -83,10 +83,10 @@
                            </chord>
                         </layer>
                      </staff>
-                     <tempo staff="1" tstamp="1.000000">Allegro, ma non troppo</tempo>
-                     <dynam staff="1" tstamp="1.000000">f</dynam>
-                     <pedal staff="2" tstamp="1.000000" dir="down" />
-                     <pedal staff="2" tstamp="3.500000" dir="up" />
+                     <tempo staff="1" tstamp="1">Allegro, ma non troppo</tempo>
+                     <dynam staff="1" tstamp="1">f</dynam>
+                     <pedal staff="2" tstamp="1" dir="down" />
+                     <pedal staff="2" tstamp="3.5" dir="up" />
                   </measure>
                   <measure n="2">
                      <staff n="1">

--- a/_tests/tempo/tempo-004.mei
+++ b/_tests/tempo/tempo-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -24,9 +24,9 @@
          </notesStmt>
          <sourceDesc>
             <source>
-              <bibl>Behind Bars, p. 183, example 2</bibl>
+               <bibl>Behind Bars, p. 183, example 2</bibl>
             </source>
-          </sourceDesc>
+         </sourceDesc>
       </fileDesc>
       <encodingDesc>
          <appInfo>
@@ -62,7 +62,7 @@
                            </chord>
                         </layer>
                      </staff>
-                     <tempo place="above" staff="1" tstamp="1.000000" midi.bpm="90">
+                     <tempo place="above" staff="1" tstamp="1" midi.bpm="90">
                         <rend rend="none" fontweight="bold">Allegro</rend>
                      </tempo>
                   </measure>
@@ -72,7 +72,7 @@
                            <note dur.ppq="2" dur="2" oct="5" pname="f" />
                         </layer>
                      </staff>
-                     <tempo place="above" staff="1" tstamp="1.000000">
+                     <tempo place="above" staff="1" tstamp="1">
                         <rend rend="none" fontweight="bold">accel.</rend>
                      </tempo>
                   </measure>
@@ -85,7 +85,7 @@
                            <note dur.ppq="2" dur="2" oct="5" pname="a" />
                         </layer>
                      </staff>
-                     <tempo place="above" staff="1" tstamp="1.000000" midi.bpm="140">
+                     <tempo place="above" staff="1" tstamp="1" midi.bpm="140">
                         <rend rend="none" fontweight="bold">Presto</rend>
                      </tempo>
                   </measure>

--- a/_tests/tie/tie-002.mei
+++ b/_tests/tie/tie-002.mei
@@ -1,100 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Tied longa notes</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017">2017</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Ties on different note values, e.g. on longa notes, are placed on the correct side.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="2.0.0" label="2">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef>
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="12" meter.unit="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1" type="m-1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="note-L4F1" dots="1" dur="long" oct="4" pname="a">
-                    <accid accid.ges="n" />
-                  </note>
-                </layer>
-              </staff>
-              <tie startid="#note-L4F1" endid="#note-L6F1" />
-            </measure>
-            <measure type="m--1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="note-L6F1" dots="1" dur="long" oct="4" pname="a">
-                    <accid accid.ges="n" />
-                  </note>
-                </layer>
-              </staff>
-            </measure>
-            <measure type="m--1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="note-L8F1" dots="1" dur="long" oct="4" pname="b">
-                    <accid accid.ges="n" />
-                  </note>
-                </layer>
-              </staff>
-              <tie startid="#note-L8F1" endid="#note-L10F1" />
-            </measure>
-            <measure type="m--1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="note-L10F1" dots="1" dur="long" oct="4" pname="b">
-                    <accid accid.ges="n" />
-                  </note>
-                </layer>
-              </staff>
-            </measure>
-            <measure type="m--1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="note-L12F1" dots="1" dur="long" oct="5" pname="c">
-                    <accid accid.ges="n" />
-                  </note>
-                </layer>
-              </staff>
-              <tie startid="#note-L12F1" endid="#note-L14F1" />
-            </measure>
-            <measure right="end" type="m--1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="note-L14F1" dots="1" dur="long" oct="5" pname="c">
-                    <accid accid.ges="n" />
-                  </note>
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Tied longa notes</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017">2017</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Ties on different note values, e.g. on longa notes, are placed on the correct side.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="2.0.0" label="2">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="12" meter.unit="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1" type="m-1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="note-L4F1" dots="1" dur="long" oct="4" pname="a">
+                              <accid accid.ges="n" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <tie startid="#note-L4F1" endid="#note-L6F1" />
+                  </measure>
+                  <measure type="m--1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="note-L6F1" dots="1" dur="long" oct="4" pname="a">
+                              <accid accid.ges="n" />
+                           </note>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure type="m--1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="note-L8F1" dots="1" dur="long" oct="4" pname="b">
+                              <accid accid.ges="n" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <tie startid="#note-L8F1" endid="#note-L10F1" />
+                  </measure>
+                  <measure type="m--1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="note-L10F1" dots="1" dur="long" oct="4" pname="b">
+                              <accid accid.ges="n" />
+                           </note>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure type="m--1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="note-L12F1" dots="1" dur="long" oct="5" pname="c">
+                              <accid accid.ges="n" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <tie startid="#note-L12F1" endid="#note-L14F1" />
+                  </measure>
+                  <measure right="end" type="m--1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="note-L14F1" dots="1" dur="long" oct="5" pname="c">
+                              <accid accid.ges="n" />
+                           </note>
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-003.mei
+++ b/_tests/tie/tie-003.mei
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Open ties</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017">2017</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Using the "tstamp" and "tstamp2" attributes, it is possible to encode open ties.</annot>
-      </notesStmt>
-    </fileDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef>
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <note xml:id="n1" dur="2" oct="4" pname="c" />
-                  <note xml:id="n2" dur="2" oct="4" pname="c" />
-                </layer>
-              </staff>
-              <tie tstamp="0.0" endid="#n1" />
-              <tie startid="#n2" tstamp2="0m+5.0" />
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Open ties</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017">2017</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Using the "tstamp" and "tstamp2" attributes, it is possible to encode open ties.</annot>
+         </notesStmt>
+      </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="n1" dur="2" oct="4" pname="c" />
+                           <note xml:id="n2" dur="2" oct="4" pname="c" />
+                        </layer>
+                     </staff>
+                     <tie tstamp="0" endid="#n1" />
+                     <tie startid="#n2" tstamp2="0m+5" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-006.mei
+++ b/_tests/tie/tie-006.mei
@@ -1,101 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Ties on chords example (3)</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017">2017</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>With "tie" elements, it is possible to specify the direction of the tie and its shape with the "curvedir" attribute.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="0.9.13">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef>
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <rest dur="16" />
-                  <beam>
-                    <note xml:id="s2n1" dur="16" oct="5" pname="c" />
-                    <note xml:id="s2n2" dur="16" oct="4" pname="g" />
-                    <note xml:id="s2n3" dur="16" oct="4" pname="e" />
-                  </beam>
-                </layer>
-              </staff>
-              <tie startid="#s2n3" endid="#s2n7" bulge="1.0 50%" curvedir="below" />
-              <tie startid="#s2n2" endid="#s2n8" bulge="1.0 50%" curvedir="above" />
-              <tie startid="#s2n1" endid="#s2n9" bulge="1.0 50%" curvedir="above" />
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2">
-                    <note xml:id="s2n6" dur="8" oct="4" pname="c" />
-                    <note xml:id="s2n7" dur="8" oct="4" pname="e" />
-                    <note xml:id="s2n8" dur="8" oct="4" pname="g" />
-                    <note xml:id="s2n9" dur="8" oct="5" pname="c" />
-                  </chord>
-                </layer>
-              </staff>
-              <tie startid="#s2n6" endid="#s2n11" />
-              <tie startid="#s2n7" endid="#s2n12" />
-              <tie startid="#s2n8" endid="#s2n13" />
-              <tie startid="#s2n9" endid="#s2n14" />
-            </measure>
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2">
-                    <note xml:id="s2n11" dur="8" oct="4" pname="c" />
-                    <note xml:id="s2n12" dur="8" oct="4" pname="e" />
-                    <note xml:id="s2n13" dur="8" oct="4" pname="g" />
-                    <note xml:id="s2n14" dur="8" oct="5" pname="c" />
-                  </chord>
-                </layer>
-              </staff>
-              <tie startid="#s2n12" endid="#s2n17" bulge="1.0 50%" curvedir="below" />
-              <tie startid="#s2n13" endid="#s2n18" bulge="1.0 50%" curvedir="above" />
-              <tie startid="#s2n14" endid="#s2n19" bulge="1.0 50%" curvedir="above" />
-            </measure>
-            <measure right="invis" n="4">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note xml:id="s2n17" dur="16" oct="4" pname="e" />
-                    <note xml:id="s2n18" dur="16" oct="4" pname="g" />
-                    <note xml:id="s2n19" dur="16" oct="5" pname="c" />
-                  </beam>
-                  <rest dur="16" />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Ties on chords example (3)</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017">2017</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>With "tie" elements, it is possible to specify the direction of the tie and its shape with the "curvedir" attribute.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="0.9.13">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <rest dur="16" />
+                           <beam>
+                              <note xml:id="s2n1" dur="16" oct="5" pname="c" />
+                              <note xml:id="s2n2" dur="16" oct="4" pname="g" />
+                              <note xml:id="s2n3" dur="16" oct="4" pname="e" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <tie startid="#s2n3" endid="#s2n7" bulge="1 50" curvedir="below" />
+                     <tie startid="#s2n2" endid="#s2n8" bulge="1 50" curvedir="above" />
+                     <tie startid="#s2n1" endid="#s2n9" bulge="1 50" curvedir="above" />
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2">
+                              <note xml:id="s2n6" dur="8" oct="4" pname="c" />
+                              <note xml:id="s2n7" dur="8" oct="4" pname="e" />
+                              <note xml:id="s2n8" dur="8" oct="4" pname="g" />
+                              <note xml:id="s2n9" dur="8" oct="5" pname="c" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <tie startid="#s2n6" endid="#s2n11" />
+                     <tie startid="#s2n7" endid="#s2n12" />
+                     <tie startid="#s2n8" endid="#s2n13" />
+                     <tie startid="#s2n9" endid="#s2n14" />
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2">
+                              <note xml:id="s2n11" dur="8" oct="4" pname="c" />
+                              <note xml:id="s2n12" dur="8" oct="4" pname="e" />
+                              <note xml:id="s2n13" dur="8" oct="4" pname="g" />
+                              <note xml:id="s2n14" dur="8" oct="5" pname="c" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <tie startid="#s2n12" endid="#s2n17" bulge="1 50" curvedir="below" />
+                     <tie startid="#s2n13" endid="#s2n18" bulge="1 50" curvedir="above" />
+                     <tie startid="#s2n14" endid="#s2n19" bulge="1 50" curvedir="above" />
+                  </measure>
+                  <measure right="invis" n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="s2n17" dur="16" oct="4" pname="e" />
+                              <note xml:id="s2n18" dur="16" oct="4" pname="g" />
+                              <note xml:id="s2n19" dur="16" oct="5" pname="c" />
+                           </beam>
+                           <rest dur="16" />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-007.mei
+++ b/_tests/tie/tie-007.mei
@@ -1,80 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Styling Ties</title>
-      </titleStmt>
-      <pubStmt>
-        <respStmt>
-          <persName role="encoder">Klaus Rettinghaus</persName>
-          <corpName role="funder">Enote GmbH</corpName>
-        </respStmt>
-        <date isodate="2020">2020</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Ties can be styled with midpoint and endpoint thickness values through SMuFL's engravingDefaults.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="unknown">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-    <extMeta><![CDATA[ { "tieEndpointThickness": 0.25, "tieMidpointThickness": 0.25 }]]></extMeta>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef>
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
-                <meterSig count="1" unit="2" form="invis" />
-              </staffDef>
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure>
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2">
-                    <note xml:id="s2n6" oct="4" pname="c" />
-                    <note xml:id="s2n7" oct="4" pname="e" />
-                    <note xml:id="s2n8" oct="4" pname="g" />
-                    <note xml:id="s2n9" oct="5" pname="c" />
-                  </chord>
-                </layer>
-              </staff>
-              <tie startid="#s2n6" endid="#s2n11" />
-              <tie startid="#s2n7" endid="#s2n12" />
-              <tie startid="#s2n8" endid="#s2n13" />
-              <tie startid="#s2n9" endid="#s2n14" />
-            </measure>
-            <measure>
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2">
-                    <note xml:id="s2n11" oct="4" pname="c" />
-                    <note xml:id="s2n12" oct="4" pname="e" />
-                    <note xml:id="s2n13" oct="4" pname="g" />
-                    <note xml:id="s2n14" oct="5" pname="c" />
-                  </chord>
-                </layer>
-              </staff>
-              <tie startid="#s2n11" tstamp2="0m+2" curvedir="below" />
-              <tie startid="#s2n14" tstamp2="0m+2" curvedir="above" />
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Styling Ties</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="encoder">Klaus Rettinghaus</persName>
+               <corpName role="funder">Enote GmbH</corpName>
+            </respStmt>
+            <date isodate="2020">2020</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Ties can be styled with midpoint and endpoint thickness values through SMuFL's engravingDefaults.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="unknown">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+      <extMeta><![CDATA[ { "tieEndpointThickness": 0.25, "tieMidpointThickness": 0.25 }]]></extMeta>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
+                        <meterSig count="1" unit="2" visible="false" />
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure>
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2">
+                              <note xml:id="s2n6" oct="4" pname="c" />
+                              <note xml:id="s2n7" oct="4" pname="e" />
+                              <note xml:id="s2n8" oct="4" pname="g" />
+                              <note xml:id="s2n9" oct="5" pname="c" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <tie startid="#s2n6" endid="#s2n11" />
+                     <tie startid="#s2n7" endid="#s2n12" />
+                     <tie startid="#s2n8" endid="#s2n13" />
+                     <tie startid="#s2n9" endid="#s2n14" />
+                  </measure>
+                  <measure>
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2">
+                              <note xml:id="s2n11" oct="4" pname="c" />
+                              <note xml:id="s2n12" oct="4" pname="e" />
+                              <note xml:id="s2n13" oct="4" pname="g" />
+                              <note xml:id="s2n14" oct="5" pname="c" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <tie startid="#s2n11" tstamp2="0m+2" curvedir="below" />
+                     <tie startid="#s2n14" tstamp2="0m+2" curvedir="above" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-008.mei
+++ b/_tests/tie/tie-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,6 +39,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <label>Piano</label>
                         <labelAbbr>Pno.</labelAbbr>
                         <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
@@ -52,7 +53,6 @@
                            <keySig sig="0" />
                            <meterSig count="2" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>

--- a/_tests/tie/tie-009.mei
+++ b/_tests/tie/tie-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tie/tie-010.mei
+++ b/_tests/tie/tie-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -79,8 +79,8 @@
                            <note xml:id="note-0000000727462467" dur="4" oct="4" pname="d" stem.dir="up" />
                         </layer>
                      </staff>
-                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+2.0000" form="dim" place="below" vgrp="80" />
-                     <dynam place="below" staff="1" tstamp="3.000000" vgrp="40">p</dynam>
+                     <hairpin staff="1" tstamp="1" tstamp2="0m+2" form="dim" place="below" vgrp="80" />
+                     <dynam place="below" staff="1" tstamp="3" vgrp="40">p</dynam>
                      <slur startid="#chord-0000002084266010" endid="#chord-0000000396353015" curvedir="above" />
                      <tie startid="#note-0000001841214710" endid="#note-0000001430999767" />
                      <tie startid="#note-0000000727462467" endid="#note-0000001423965029" curvedir="above" />
@@ -140,10 +140,10 @@
                               <rest dur="8" />
                            </layer>
                         </staff>
-                        <slur staff="1" tstamp="0.000000" endid="#chord-0000000528813094" curvedir="above" />
-                        <tie staff="1" tstamp="0.000000" endid="#note-0000000345492439" />
-                        <slur staff="2" tstamp="0.000000" endid="#chord-0000000243822164" curvedir="above" />
-                        <tie staff="2" tstamp="0.000000" endid="#note-0000000121171713" />
+                        <slur staff="1" tstamp="0" endid="#chord-0000000528813094" curvedir="above" />
+                        <tie staff="1" tstamp="0" endid="#note-0000000345492439" />
+                        <slur staff="2" tstamp="0" endid="#chord-0000000243822164" curvedir="above" />
+                        <tie staff="2" tstamp="0" endid="#note-0000000121171713" />
                      </measure>
                   </ending>
                   <pb />

--- a/_tests/tie/tie-011.mei
+++ b/_tests/tie/tie-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -69,14 +69,14 @@
                            <rest dur="4" />
                         </layer>
                      </staff>
-                     <lv startid="#n1tuq93d" tstamp2="0m+3.0" />
-                     <lv startid="#nciq2mh" tstamp2="0m+3.0" />
-                     <lv startid="#nv4fpxf" tstamp2="0m+3.0" />
-                     <lv startid="#ndc9tyk" tstamp2="0m+3.0" />
-                     <lv startid="#nqgqi0" tstamp2="0m+3.0" />
-                     <lv startid="#n1tlo9m4" tstamp2="0m+3.0" />
-                     <lv startid="#ngzt3e1" tstamp2="0m+3.0" />
-                     <lv startid="#nvuu01k" tstamp2="0m+3.0" />
+                     <lv startid="#n1tuq93d" tstamp2="0m+3" />
+                     <lv startid="#nciq2mh" tstamp2="0m+3" />
+                     <lv startid="#nv4fpxf" tstamp2="0m+3" />
+                     <lv startid="#ndc9tyk" tstamp2="0m+3" />
+                     <lv startid="#nqgqi0" tstamp2="0m+3" />
+                     <lv startid="#n1tlo9m4" tstamp2="0m+3" />
+                     <lv startid="#ngzt3e1" tstamp2="0m+3" />
+                     <lv startid="#nvuu01k" tstamp2="0m+3" />
                   </measure>
                   <measure right="end" n="2">
                      <staff n="1">
@@ -119,10 +119,10 @@
                      <lv startid="#nxqqg27" tstamp2="0m+3.6" />
                      <lv startid="#n1l7h763" tstamp2="0m+3.6" />
                      <lv startid="#n1osb8h3" tstamp2="0m+3.6" />
-                     <lv startid="#n171q2xw" tstamp2="0m+3.0" />
-                     <lv startid="#n1rb8tvq" tstamp2="0m+3.0" />
-                     <lv startid="#n1h2en3w" tstamp2="0m+3.0" />
-                     <lv startid="#n1ymbffp" tstamp2="0m+3.0" />
+                     <lv startid="#n171q2xw" tstamp2="0m+3" />
+                     <lv startid="#n1rb8tvq" tstamp2="0m+3" />
+                     <lv startid="#n1h2en3w" tstamp2="0m+3" />
+                     <lv startid="#n1ymbffp" tstamp2="0m+3" />
                   </measure>
                </section>
             </score>

--- a/_tests/trill/trill-001.mei
+++ b/_tests/trill/trill-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -47,7 +47,7 @@
                            <note dur="4" oct="4" pname="g" stem.dir="down" />
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="1.000000" tstamp2="0m+1.9000" />
+                     <trill staff="1" tstamp="1" tstamp2="0m+1.9" />
                   </measure>
                   <measure right="dbl" n="2">
                      <staff n="1">
@@ -72,7 +72,7 @@
                            <note dur="4" oct="4" pname="b" stem.dir="down" />
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="1.000000" place="above" />
+                     <trill staff="1" tstamp="1" place="above" />
                   </measure>
                   <measure right="dbl" n="4">
                      <staff n="1">
@@ -99,7 +99,7 @@
                            <note dur="4" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="1.000000" color="fuchsia" place="below" />
+                     <trill color="fuchsia" staff="1" tstamp="1" place="below" />
                   </measure>
                   <measure right="dbl" n="6">
                      <staff n="1">

--- a/_tests/trill/trill-002.mei
+++ b/_tests/trill/trill-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -27,7 +27,7 @@
          <mdiv>
             <score>
                <scoreDef>
-                  <staffGrp symbol="brace" bar.thru="true">
+                  <staffGrp bar.thru="true" symbol="brace">
                      <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="5f" />
                      <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="5f" />
                   </staffGrp>
@@ -65,11 +65,11 @@
                            </chord>
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">sotto voce</dir>
-                     <trill staff="1" tstamp="1.000000" />
+                     <dir place="above" staff="1" tstamp="1">sotto voce</dir>
+                     <trill staff="1" tstamp="1" />
                      <slur staff="1" startid="#note-L9F2" endid="#note-L14F2" />
-                     <pedal staff="2" tstamp="1.000000" dir="down" />
-                     <pedal staff="2" tstamp="3.500000" dir="up" />
+                     <pedal staff="2" tstamp="1" dir="down" />
+                     <pedal staff="2" tstamp="3.5" dir="up" />
                   </measure>
                </section>
             </score>

--- a/_tests/trill/trill-003.mei
+++ b/_tests/trill/trill-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -39,7 +39,7 @@
                            <note dur="1" oct="4" pname="c" accid.ges="n" />
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="1.000000" />
+                     <trill staff="1" tstamp="1" />
                   </measure>
                   <measure right="end" n="2">
                      <staff n="1">
@@ -47,11 +47,11 @@
                            <note dur="1" oct="4" pname="e" accid.ges="n" />
                         </layer>
                      </staff>
-                     <dir place="above" staff="1" tstamp="1.000000">legatissimo</dir>
-                     <fermata staff="1" tstamp="1.000000" place="above" />
-                     <tempo staff="1" tstamp="1.000000">Adagio</tempo>
-                     <trill staff="1" tstamp="1.000000" />
-                     <dynam place="above" staff="1" tstamp="1.000000">p</dynam>
+                     <dir place="above" staff="1" tstamp="1">legatissimo</dir>
+                     <fermata staff="1" tstamp="1" place="above" />
+                     <tempo staff="1" tstamp="1">Adagio</tempo>
+                     <trill staff="1" tstamp="1" />
+                     <dynam place="above" staff="1" tstamp="1">p</dynam>
                   </measure>
                </section>
             </score>

--- a/_tests/trill/trill-004.mei
+++ b/_tests/trill/trill-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -48,7 +48,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <trill staff="1" tstamp="1.000000" />
+                     <trill staff="1" tstamp="1" />
                   </measure>
                   <measure right="end" n="2">
                      <staff n="1">
@@ -58,7 +58,7 @@
                            </note>
                         </layer>
                      </staff>
-                     <fermata staff="1" tstamp="1.000000" place="above" />
+                     <fermata staff="1" tstamp="1" place="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/trill/trill-005.mei
+++ b/_tests/trill/trill-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -28,7 +28,7 @@
             <score>
                <scoreDef ppq="256" meter.count="2" meter.unit="4">
                   <staffGrp>
-                     <staffGrp symbol="brace" n="1">
+                     <staffGrp n="1" symbol="brace">
                         <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" keysig="2f" />
                         <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.mode="major" keysig="2f" />
                      </staffGrp>
@@ -39,19 +39,19 @@
                      <staff n="1">
                         <layer n="1">
                            <beam>
-                              <note xml:id="m-72" dur="8" pnum="70" oct="4" pname="b" stem.dir="down">
+                              <note xml:id="m-72" dur="8" oct="4" pname="b" pnum="70" stem.dir="down">
                                  <accid accid.ges="f" />
                               </note>
-                              <note dur="8" pnum="82" oct="5" pname="b" stem.dir="down">
+                              <note dur="8" oct="5" pname="b" pnum="82" stem.dir="down">
                                  <accid accid.ges="f" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="m-77" dots="1" dur="8" pnum="80" oct="5" pname="a" stem.dir="down">
+                              <note xml:id="m-77" dots="1" dur="8" oct="5" pname="a" pnum="80" stem.dir="down">
                                  <accid accid="f" />
                               </note>
-                              <note dur="32" pnum="79" oct="5" pname="g" stem.dir="down" />
-                              <note dur="32" pnum="78" oct="5" pname="f" stem.dir="down">
+                              <note dur="32" oct="5" pname="g" pnum="79" stem.dir="down" />
+                              <note dur="32" oct="5" pname="f" pnum="78" stem.dir="down">
                                  <accid accid="s" />
                               </note>
                            </beam>
@@ -60,13 +60,13 @@
                      <staff n="2">
                         <layer n="1">
                            <chord dur="8" stem.dir="down">
-                              <note dur="8" pnum="55" oct="3" pname="g" />
-                              <note dur="8" pnum="62" oct="4" pname="d" />
+                              <note dur="8" oct="3" pname="g" pnum="55" />
+                              <note dur="8" oct="4" pname="d" pnum="62" />
                            </chord>
                            <rest dur="8" />
                            <chord dur="4" stem.dir="down">
-                              <note dur="4" pnum="50" oct="3" pname="d" />
-                              <note dur="4" pnum="58" oct="3" pname="b">
+                              <note dur="4" oct="3" pname="d" pnum="50" />
+                              <note dur="4" oct="3" pname="b" pnum="58">
                                  <accid accid.ges="f" />
                               </note>
                            </chord>
@@ -78,16 +78,16 @@
                   <measure n="2">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="m-172" dur="8" pnum="70" oct="4" pname="b" stem.dir="down">
+                           <note xml:id="m-172" dur="8" oct="4" pname="b" pnum="70" stem.dir="down">
                               <accid accid.ges="f" />
                            </note>
-                           <note dur="8" pnum="82" oct="5" pname="b" stem.dir="down">
+                           <note dur="8" oct="5" pname="b" pnum="82" stem.dir="down">
                               <accid accid.ges="f" />
                            </note>
                            <beam>
-                              <note xml:id="m-177" dots="1" dur="8" pnum="80" oct="5" pname="a" stem.dir="down" />
-                              <note dur="32" pnum="79" oct="5" pname="g" stem.dir="down" />
-                              <note dur="32" pnum="78" oct="5" pname="f" stem.dir="down">
+                              <note xml:id="m-177" dots="1" dur="8" oct="5" pname="a" pnum="80" stem.dir="down" />
+                              <note dur="32" oct="5" pname="g" pnum="79" stem.dir="down" />
+                              <note dur="32" oct="5" pname="f" pnum="78" stem.dir="down">
                                  <accid accid="s" />
                               </note>
                            </beam>
@@ -96,13 +96,13 @@
                      <staff n="2">
                         <layer n="1">
                            <chord dur="8" stem.dir="down">
-                              <note dur="8" pnum="55" oct="3" pname="g" />
-                              <note dur="8" pnum="62" oct="4" pname="d" />
+                              <note dur="8" oct="3" pname="g" pnum="55" />
+                              <note dur="8" oct="4" pname="d" pnum="62" />
                            </chord>
                            <rest dur="8" />
                            <chord dur="4" stem.dir="down">
-                              <note dur="4" pnum="50" oct="3" pname="d" />
-                              <note dur="4" pnum="58" oct="3" pname="b">
+                              <note dur="4" oct="3" pname="d" pnum="50" />
+                              <note dur="4" oct="3" pname="b" pnum="58">
                                  <accid accid.ges="f" />
                               </note>
                            </chord>

--- a/_tests/trill/trill-006.mei
+++ b/_tests/trill/trill-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -55,7 +55,7 @@
                            <note dur="1" oct="5" pname="c" />
                         </layer>
                      </staff>
-                     <trill tstamp="1.000000" tstamp2="1m+1.0000" lstartsym="none" />
+                     <trill tstamp="1" tstamp2="1m+1" lstartsym="none" />
                   </measure>
                   <measure>
                      <staff n="1">

--- a/_tests/trill/trill-007.mei
+++ b/_tests/trill/trill-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-001.mei
+++ b/_tests/tuplet/tuplet-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-002.mei
+++ b/_tests/tuplet/tuplet-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-003.mei
+++ b/_tests/tuplet/tuplet-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-004.mei
+++ b/_tests/tuplet/tuplet-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-005.mei
+++ b/_tests/tuplet/tuplet-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-006.mei
+++ b/_tests/tuplet/tuplet-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-008.mei
+++ b/_tests/tuplet/tuplet-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-009.mei
+++ b/_tests/tuplet/tuplet-009.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-010.mei
+++ b/_tests/tuplet/tuplet-010.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-011.mei
+++ b/_tests/tuplet/tuplet-011.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-012.mei
+++ b/_tests/tuplet/tuplet-012.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-013.mei
+++ b/_tests/tuplet/tuplet-013.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-014.mei
+++ b/_tests/tuplet/tuplet-014.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-015.mei
+++ b/_tests/tuplet/tuplet-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-016.mei
+++ b/_tests/tuplet/tuplet-016.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-017.mei
+++ b/_tests/tuplet/tuplet-017.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-018.mei
+++ b/_tests/tuplet/tuplet-018.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-019.mei
+++ b/_tests/tuplet/tuplet-019.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-020.mei
+++ b/_tests/tuplet/tuplet-020.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-021.mei
+++ b/_tests/tuplet/tuplet-021.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/tuplet/tuplet-022.mei
+++ b/_tests/tuplet/tuplet-022.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -36,6 +36,7 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp bar.thru="true">
+                        <grpSym symbol="brace" />
                         <staffDef n="1" lines="5">
                            <clef shape="G" line="2" />
                            <keySig mode="major" sig="0" />
@@ -46,7 +47,6 @@
                            <keySig mode="major" sig="0" />
                            <meterSig count="4" unit="4" />
                         </staffDef>
-                        <grpSym symbol="brace" />
                      </staffGrp>
                   </staffGrp>
                </scoreDef>

--- a/_tests/tuplet/tuplet-023.mei
+++ b/_tests/tuplet/tuplet-023.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/turn/turn-001.mei
+++ b/_tests/turn/turn-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/turn/turn-002.mei
+++ b/_tests/turn/turn-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/turn/turn-003.mei
+++ b/_tests/turn/turn-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/turn/turn-004.mei
+++ b/_tests/turn/turn-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -68,9 +68,9 @@
                            </beam>
                         </layer>
                      </staff>
-                     <turn staff="1" startid="#note-L6F1" form="upper" delayed="true" />
+                     <turn staff="1" startid="#note-L6F1" delayed="true" form="upper" />
                      <tie startid="#note-L6F1" endid="#note-L7F1" />
-                     <turn staff="1" startid="#note-L6F2" form="upper" delayed="true" />
+                     <turn staff="1" startid="#note-L6F2" delayed="true" form="upper" />
                      <tie startid="#note-L6F2" endid="#note-L7F2" />
                   </measure>
                </section>

--- a/_tests/turn/turn-005.mei
+++ b/_tests/turn/turn-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -32,32 +32,31 @@
    </meiHead>
    <music>
       <body>
-         <mdiv xml:id="m2k1yrz">
-            <score xml:id="s13r9c4p">
-               <scoreDef xml:id="s1ah6gqo">
-                  <staffGrp xml:id="sw3ur0">
-                     <staffDef xml:id="s97u2tv" n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" />
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
-               <section xml:id="sefudge">
-                  <measure xml:id="m595al7" right="dbl" n="1">
-                     <staff xml:id="s1wwg7oj" n="1">
-                        <layer xml:id="l3jwgtx" n="1">
+               <section>
+                  <measure right="dbl" n="1">
+                     <staff n="1">
+                        <layer n="1">
                            <note xml:id="ex_0026251991" dur="4" oct="4" pname="g" />
                            <note xml:id="ex_1783472943" dur="4" oct="4" pname="g" />
                            <note xml:id="ex_0290776165" dur="4" oct="4" pname="g" />
                            <note xml:id="ex_1264550794" dur="4" oct="4" pname="g" />
                         </layer>
                      </staff>
-                     <turn xml:id="tz2mhpe" staff="1" startid="#ex_0026251991" accidlower="s" form="lower" />
-                     <turn xml:id="teikehw" staff="1" startid="#ex_1783472943" accidupper="f" form="upper" />
-                     <turn xml:id="t181aodg" type="vertical" staff="1" startid="#ex_0290776165" glyph.auth="smufl" glyph.num="U+E56B" accidlower="s" form="lower" />
-                     <turn xml:id="t1xqgn4w" type="vertical" staff="1" startid="#ex_1264550794" glyph.auth="smufl" glyph.num="U+E56A" accidupper="f" form="upper" />
-                     
+                     <turn staff="1" startid="#ex_0026251991" accidlower="s" form="lower" />
+                     <turn staff="1" startid="#ex_1783472943" accidupper="f" form="upper" />
+                     <turn type="vertical" staff="1" startid="#ex_0290776165" glyph.auth="smufl" glyph.num="U+E56B" accidlower="s" form="lower" />
+                     <turn type="vertical" staff="1" startid="#ex_1264550794" glyph.auth="smufl" glyph.num="U+E56A" accidupper="f" form="upper" />
                   </measure>
-                  <measure xml:id="m1rfk0cj" right="dbl" n="1">
-                     <staff xml:id="s172gaq7" n="1">
-                        <layer xml:id="l1i5zh33" n="1">
+                  <measure right="dbl" n="1">
+                     <staff n="1">
+                        <layer n="1">
                            <note xml:id="nmjj4ps" dur="2" oct="4" pname="f" />
                            <note xml:id="n11rxuei" dur="2" oct="4" pname="f" />
                         </layer>

--- a/_tests/turn/turn-006.mei
+++ b/_tests/turn/turn-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -12,7 +12,7 @@
             </respStmt>
          </titleStmt>
          <pubStmt>
-            <date isodate="2023-03-03"></date>
+            <date isodate="2023-03-03" />
             <pubPlace>
                <ref target="https://github.com/rism-digital/verovio/issues/3266" />
             </pubPlace>
@@ -58,7 +58,7 @@
                         </layer>
                      </staff>
                      <turn staff="1" startid="#note-L4F1S2" accidupper="f" accidlower="s" form="lower" />
-                     <dir place="below" staff="1" tstamp="1.000000">
+                     <dir place="below" staff="1" tstamp="1">
                         <rend fontstyle="normal">not delayed</rend>
                      </dir>
                   </measure>
@@ -75,7 +75,7 @@
                         </layer>
                      </staff>
                      <turn staff="1" startid="#note-L8F1S1" accidupper="f" accidlower="s" delayed="true" form="lower" />
-                     <dir place="below" staff="1" tstamp="1.000000">
+                     <dir place="below" staff="1" tstamp="1">
                         <rend fontstyle="normal">delayed</rend>
                      </dir>
                   </measure>

--- a/_tests/unison/unison-001.mei
+++ b/_tests/unison/unison-001.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/unison/unison-002.mei
+++ b/_tests/unison/unison-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/unison/unison-003.mei
+++ b/_tests/unison/unison-003.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/unison/unison-004.mei
+++ b/_tests/unison/unison-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/unison/unison-005.mei
+++ b/_tests/unison/unison-005.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -10,7 +10,7 @@
          <pubStmt>
             <date isodate="2017-07-28">28 Jul 2017</date>
             <pubPlace>
-               <ref/>
+               <ref />
             </pubPlace>
          </pubStmt>
          <seriesStmt>
@@ -33,9 +33,9 @@
          <mdiv>
             <score>
                <scoreDef midi.bpm="92">
-                  <staffGrp symbol="brace" bar.thru="true">
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="3s" meter.count="4" meter.unit="4" meter.sym="common" />
-                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="3s" meter.count="4" meter.unit="4" meter.sym="common" />
+                  <staffGrp bar.thru="true" symbol="brace">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" keysig="3s" meter.count="4" meter.unit="4" meter.sym="common" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" keysig="3s" meter.count="4" meter.unit="4" meter.sym="common" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/unison/unison-006.mei
+++ b/_tests/unison/unison-006.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -10,7 +10,7 @@
          <pubStmt>
             <date isodate="2017-07-28">28 Jul 2017</date>
             <pubPlace>
-               <ref/>
+               <ref />
             </pubPlace>
          </pubStmt>
          <seriesStmt>

--- a/_tests/unison/unison-007.mei
+++ b/_tests/unison/unison-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>


### PR DESCRIPTION
This updates (almost) all files to MEI 5.1 using latest development version of Verovio. 

Things to note:

- several files were still on MEI 4
- because of the improved order of attributes in the ODD the order of attributes also changed in the output. 
- by using the `--remove-ids` some neglectible IDs were removed, in cases with bigger changes the file was left untouched
- the files `dir-011.mei` and `dir-012.mei` are encoded in UTF-16, so they were not updated (should be discussed)
- biggest improvement (and change) is the new output for decimal numbers on `@tstamp` and others
- some files showed problems with lost information, those were held back (I'll open tickets for these cases)
- in cases where attributes are changed into elements (like ties, fermatas) the file was held back
