### PR TITLE
some final updates

### DIFF
--- a/_tests/artic/artic-002.mei
+++ b/_tests/artic/artic-002.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/clef/clef-006.mei
+++ b/_tests/clef/clef-006.mei
@@ -61,7 +61,7 @@
                   <measure n="1">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="1" oct="3" pname="g">
+                           <note xml:id="n6iio2o" dur="1" oct="3" pname="g">
                               <verse>
                                  <syl>Sol!</syl>
                               </verse>
@@ -70,7 +70,7 @@
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <note dur="1" oct="3" pname="g">
+                           <note xml:id="n1uirdzn" dur="1" oct="3" pname="g">
                               <verse>
                                  <syl>Sol!</syl>
                               </verse>
@@ -81,12 +81,12 @@
                   <measure right="dbl" n="2">
                      <staff n="1">
                         <layer n="1">
-                           <mRest fermata="above" />
+                           <mRest xml:id="m1hab2jh" fermata="above" />
                         </layer>
                      </staff>
                      <staff n="2">
                         <layer n="1">
-                           <mRest fermata="above" />
+                           <mRest xml:id="m1jo4cik" fermata="above" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/fermata/fermata-002.mei
+++ b/_tests/fermata/fermata-002.mei
@@ -61,8 +61,8 @@
                      <fermata staff="1" startid="#chord-000000067789064" form="inv" shape="angular" place="below" />
                      <fermata staff="1" startid="#rest-000000131319457" form="norm" shape="square" place="above" />
                      <fermata staff="1" startid="#rest-000000070546468" form="inv" shape="square" place="above" />
-                     <fermata staff="1" tstamp="5.000000" place="above" />
-                     <fermata staff="1" tstamp="5.000000" place="below" />
+                     <fermata staff="1" tstamp="5" place="above" />
+                     <fermata staff="1" tstamp="5" place="below" />
                   </measure>
                   <measure right="end" n="2">
                      <staff n="1">

--- a/_tests/mensural/mensural-004.mei
+++ b/_tests/mensural/mensural-004.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -31,7 +31,7 @@
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" notationtype="mensural.black" />
+                     <staffDef n="1" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <section>

--- a/_tests/mensural/mensural-007.mei
+++ b/_tests/mensural/mensural-007.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/_tests/mensural/mensural-008.mei
+++ b/_tests/mensural/mensural-008.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -34,16 +34,16 @@
             <score>
                <scoreDef>
                   <staffGrp n="1" symbol="bracket">
-                     <staffDef clef.line="3" clef.shape="C" lines="5" modusmaior="2" modusminor="2" n="1" notationtype="mensural" prolatio="2" tempus="3">
+                     <staffDef n="1" notationtype="mensural" lines="5" clef.shape="C" clef.line="3" modusmaior="2" modusminor="2" prolatio="2" tempus="3">
                         <label>default</label>
                      </staffDef>
-                     <staffDef clef.line="3" clef.shape="C" lines="5" modusmaior="2" modusminor="2" n="2" notationtype="mensural" prolatio="2" tempus="3">
+                     <staffDef n="2" notationtype="mensural" lines="5" clef.shape="C" clef.line="3" modusmaior="2" modusminor="2" prolatio="2" tempus="3">
                         <label>dotOfPerf</label>
                      </staffDef>
-                     <staffDef clef.line="3" clef.shape="C" lines="5" modusmaior="2" modusminor="2" n="3" notationtype="mensural" prolatio="2" tempus="3">
+                     <staffDef n="3" notationtype="mensural" lines="5" clef.shape="C" clef.line="3" modusmaior="2" modusminor="2" prolatio="2" tempus="3">
                         <label>smallNote</label>
                      </staffDef>
-                     <staffDef clef.line="3" clef.shape="C" lines="5" modusmaior="2" modusminor="2" n="4" notationtype="mensural" prolatio="2" tempus="3">
+                     <staffDef n="4" notationtype="mensural" lines="5" clef.shape="C" clef.line="3" modusmaior="2" modusminor="2" prolatio="2" tempus="3">
                         <label>ref</label>
                      </staffDef>
                   </staffGrp>
@@ -51,50 +51,50 @@
                <section>
                   <staff n="1">
                      <layer n="1">
-                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" sign="O" dot="false"/>
+                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" dot="false" sign="O" />
                         <!-- 1 Semibreve - Imperfection a.p.p. -->
-                        <note dur="brevis" oct="4" pname="c" color="violet"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" oct="4" pname="c"/>
-                        <barLine form="dashed"/>
+                        <note dur="brevis" oct="4" pname="c" color="violet" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="c" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                   <staff n="2">
                      <layer n="1">
-                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" sign="O" dot="false"/>
+                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" dot="false" sign="O" />
                         <!-- 1 Semibreve - EXCEPTION: Dot of Division - Imperfection a.p.a. -->
-                        <note dur="brevis" oct="4" pname="c"/>
-                        <dot/>
-                        <barLine form="dashed"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="brevis" oct="4" pname="c" color="violet"/>
-                        <barLine form="dashed"/>
+                        <note dur="brevis" oct="4" pname="c" />
+                        <dot />
+                        <barLine form="dashed" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="brevis" oct="4" pname="c" color="violet" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                   <staff n="3">
                      <layer n="1">
-                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" sign="O" dot="false"/>
+                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" dot="false" sign="O" />
                         <!-- 1 Semibreve - EXCEPTION: Start with Short Note - Imperfection a.p.a. -->
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="brevis" oct="4" pname="c" color="violet"/>
-                        <barLine form="dashed"/>
-                        <rest dur="brevis"/>
-                        <barLine form="dashed"/>
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="brevis" oct="4" pname="c" color="violet" />
+                        <barLine form="dashed" />
+                        <rest dur="brevis" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                   <staff n="4">
                      <layer n="1">
-                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" sign="O" dot="false"/>
+                        <mensur modusmaior="2" modusminor="2" prolatio="2" tempus="3" dot="false" sign="O" />
                         <!-- reference -->
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <barLine form="dashed"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <barLine form="dashed"/>
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <barLine form="dashed" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/_tests/phrase/phrase-001.mei
+++ b/_tests/phrase/phrase-001.mei
@@ -42,7 +42,7 @@
                         </layer>
                      </staff>
                      <slur staff="1" startid="#note-000000180893861" endid="#note-000000090536214" />
-                     <dir place="above" staff="1" tstamp="2.000000">a tempo</dir>
+                     <dir place="above" staff="1" tstamp="2">a tempo</dir>
                      <phrase staff="1" startid="#note-000000034369893" endid="#note-000000110366772" />
                   </measure>
                   <measure n="2">

--- a/_tests/score/score-015.mei
+++ b/_tests/score/score-015.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
    <meiHead>
       <fileDesc>
          <titleStmt>
@@ -29,11 +29,11 @@
                <scoreDef>
                   <staffGrp>
                      <staffGrp symbol="bracket">
-                         <staffDef n="4" lines="5" meter.count="6" meter.unit="8">
-                             <label>Violoncello</label>
-                             <labelAbbr>Vc.</labelAbbr>
-                             <clef shape="F" line="4" />
-                         </staffDef>
+                        <staffDef n="4" lines="5" meter.count="6" meter.unit="8">
+                           <label>Violoncello</label>
+                           <labelAbbr>Vc.</labelAbbr>
+                           <clef shape="F" line="4" />
+                        </staffDef>
                         <staffDef n="2" lines="5" meter.count="6" meter.unit="8">
                            <label>Violin II</label>
                            <labelAbbr>Vln.II</labelAbbr>
@@ -44,895 +44,895 @@
                            <labelAbbr>Vla.</labelAbbr>
                            <clef shape="C" line="3" />
                         </staffDef>
-                         <staffDef n="1" lines="5" meter.count="6" meter.unit="8">
-                             <label>Violin I</label>
-                             <labelAbbr>Vln. I</labelAbbr>
-                             <clef shape="G" line="2" />
-                         </staffDef>
+                        <staffDef n="1" lines="5" meter.count="6" meter.unit="8">
+                           <label>Violin I</label>
+                           <labelAbbr>Vln. I</labelAbbr>
+                           <clef shape="G" line="2" />
+                        </staffDef>
                      </staffGrp>
                   </staffGrp>
                </scoreDef>
-               <section xml:id="s1">
-                  <measure xml:id="m1mil3yd" metcon="false" n="1">
-                     <staff xml:id="m1s1" n="1">
-                        <layer xml:id="m1s1l1" n="1">
-                           <note xml:id="n18cgnc5" dur="8" pname="b" oct="3" stem.dir="up">
+               <section>
+                  <measure metcon="false" n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="n18cgnc5" dur="8" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <staff xml:id="m1s2" n="2">
-                        <layer xml:id="m1s2l1" n="1">
-                           <note xml:id="n6o7k2t" dur="8" pname="b" oct="3" stem.dir="up">
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="8" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <staff xml:id="m1s3" n="3">
-                        <layer xml:id="m1s3l1" n="1">
-                           <note xml:id="nft6vvn" dur="8" pname="b" oct="3" stem.dir="up">
+                     <staff n="3">
+                        <layer n="1">
+                           <note dur="8" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <staff xml:id="m1s4" n="4">
-                        <layer xml:id="m1s4l1" n="1">
-                           <note xml:id="n1xy33zd" dur="8" pname="b" oct="2" stem.dir="up">
+                     <staff n="4">
+                        <layer n="1">
+                           <note dur="8" oct="2" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <dir xml:id="d8tryjj" startid="#n18cgnc5" place="above">Presto</dir>
+                     <dir place="above" startid="#n18cgnc5">Presto</dir>
                   </measure>
-                  <measure xml:id="m1haaph7" n="2">
-                     <staff xml:id="m2s1" n="1">
-                        <layer xml:id="m2s1l1" n="1">
-                           <note xml:id="nb5ej3p" dur="4" pname="b" oct="3" stem.dir="up">
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="n1ptbmqt" dur="8" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="n18s3fsx" dur="4" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="nkk8mux" dur="8" pname="f" oct="4" stem.dir="up" />
+                           <note dur="8" oct="4" pname="d" stem.dir="up" />
+                           <note dur="4" oct="4" pname="d" stem.dir="up" />
+                           <note dur="8" oct="4" pname="f" stem.dir="up" />
                         </layer>
                      </staff>
-                     <staff xml:id="m2s2" n="2">
-                        <layer xml:id="m2s2l1" n="1">
-                           <note xml:id="na2vz2j" dur="4" pname="b" oct="3" stem.dir="up">
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="n16c16zs" dur="8" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="n1r4sbj3" dur="4" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="n1l27xpa" dur="8" pname="f" oct="4" stem.dir="up" />
+                           <note dur="8" oct="4" pname="d" stem.dir="up" />
+                           <note dur="4" oct="4" pname="d" stem.dir="up" />
+                           <note dur="8" oct="4" pname="f" stem.dir="up" />
                         </layer>
                      </staff>
-                     <staff xml:id="m2s3" n="3">
-                        <layer xml:id="m2s3l1" n="1">
-                           <note xml:id="n1abdtxg" dur="4" pname="b" oct="3" stem.dir="up">
+                     <staff n="3">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="n1aubkm4" dur="8" pname="d" oct="4" stem.dir="down" />
-                           <note xml:id="n3o7w80" dur="4" pname="d" oct="4" stem.dir="down" />
-                           <note xml:id="n19nlcjk" dur="8" pname="f" oct="4" stem.dir="down" />
+                           <note dur="8" oct="4" pname="d" stem.dir="down" />
+                           <note dur="4" oct="4" pname="d" stem.dir="down" />
+                           <note dur="8" oct="4" pname="f" stem.dir="down" />
                         </layer>
                      </staff>
-                     <staff xml:id="m2s4" n="4">
-                        <layer xml:id="m2s4l1" n="1">
-                           <note xml:id="n1qe82r6" dur="4" pname="b" oct="2" stem.dir="up">
+                     <staff n="4">
+                        <layer n="1">
+                           <note dur="4" oct="2" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="n7ck6xk" dur="8" pname="d" oct="3" stem.dir="down" />
-                           <note xml:id="nkli5p2" dur="4" pname="d" oct="3" stem.dir="down" />
-                           <note xml:id="n3nuhi1" dur="8" pname="f" oct="3" stem.dir="down" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure xml:id="m1iw88tw" n="3">
-                     <staff xml:id="m3s1" n="1">
-                        <layer xml:id="m3s1l1" n="1">
-                           <note xml:id="njq629v" dur="4" pname="f" oct="4" stem.dir="up" />
-                           <note xml:id="nyg8rwx" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n1goo86t" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <note xml:id="n1o3y8ii" dur="8" pname="f" oct="5" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m3s2" n="2">
-                        <layer xml:id="m3s2l1" n="1">
-                           <note xml:id="n11mfz3l" dur="4" pname="f" oct="4" stem.dir="up" />
-                           <note xml:id="n385mw4" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="npv2del" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <note xml:id="n1fyszsx" dur="8" pname="d" oct="5" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m3s3" n="3">
-                        <layer xml:id="m3s3l1" n="1">
-                           <note xml:id="n1eucmht" dur="4" pname="f" oct="4" stem.dir="down" />
-                           <note xml:id="n1j2h9lu" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n1fzru9q" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <rest xml:id="rhow912" dur="8" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m3s4" n="4">
-                        <layer xml:id="m3s4l1" n="1">
-                           <note xml:id="n15pcdbj" dur="4" pname="f" oct="3" stem.dir="down" />
-                           <note xml:id="n1oip5g" dur="8" pname="b" oct="3" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n197mij9" dur="4" pname="b" oct="3" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <rest xml:id="r1socyiv" dur="8" />
+                           <note dur="8" oct="3" pname="d" stem.dir="down" />
+                           <note dur="4" oct="3" pname="d" stem.dir="down" />
+                           <note dur="8" oct="3" pname="f" stem.dir="down" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="mc2rpbz" n="4">
-                     <staff xml:id="m4s1" n="1">
-                        <layer xml:id="m4s1l1" n="1">
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="up" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <note dur="8" oct="5" pname="f" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="up" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <note dur="8" oct="5" pname="d" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="down" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="f" stem.dir="down" />
+                           <note dur="8" oct="3" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="3" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1xva0rq" dur="8" pname="f" oct="5" stem.dir="down" />
-                              <note xml:id="nse8zo1" dur="8" pname="b" oct="5" stem.dir="down">
+                              <note xml:id="n1xva0rq" dur="8" oct="5" pname="f" stem.dir="down" />
+                              <note xml:id="nse8zo1" dur="8" oct="5" pname="b" stem.dir="down">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="na6b6ug" dur="8" pname="g" oct="5" stem.dir="down">
-                                 <artic xml:id="a1l75bjy" artic="stacc" place="above" />
+                              <note dur="8" oct="5" pname="g" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
-                           <note xml:id="ng0sev0" dur="4" pname="f" oct="5" stem.dir="down" />
-                           <rest xml:id="r1k6dr82" dur="8" />
+                           <note dur="4" oct="5" pname="f" stem.dir="down" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m4s2" n="2">
-                        <layer xml:id="m4s2l1" n="1">
-                           <note xml:id="npwxyyz" dur="4" pname="d" oct="5" stem.dir="down" />
-                           <note xml:id="n9uz0hf" dur="8" pname="e" oct="5" stem.dir="down">
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="5" pname="d" stem.dir="down" />
+                           <note dur="8" oct="5" pname="e" stem.dir="down">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="n126fb8y" dur="4" pname="d" oct="5" stem.dir="down" />
-                           <note xml:id="n11s87he" dur="8" pname="d" oct="5" stem.dir="down" />
+                           <note dur="4" oct="5" pname="d" stem.dir="down" />
+                           <note dur="8" oct="5" pname="d" stem.dir="down" />
                         </layer>
                      </staff>
-                     <staff xml:id="m4s3" n="3">
-                        <layer xml:id="m4s3l1" n="1">
-                           <rest xml:id="rq7ccr2" dur="4" />
-                           <rest xml:id="ricqgng" dur="8" />
-                           <rest xml:id="r1c1h65p" dur="4" />
-                           <note xml:id="n8hr4i2" dur="8" pname="b" oct="4" stem.dir="down">
+                     <staff n="3">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
                               <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <staff xml:id="m4s4" n="4">
-                        <layer xml:id="m4s4l1" n="1">
-                           <rest xml:id="r1nle2f" dur="4" />
-                           <rest xml:id="rccja6f" dur="8" />
-                           <rest xml:id="r14hak9q" dur="4" />
-                           <note xml:id="nhq0o53" dur="8" pname="f" oct="3" stem.dir="down" />
+                     <staff n="4">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <note dur="8" oct="3" pname="f" stem.dir="down" />
                         </layer>
                      </staff>
-                     <slur xml:id="s1mgg5mz" startid="#n1xva0rq" curvedir="above" endid="#nse8zo1" />
+                     <slur startid="#n1xva0rq" endid="#nse8zo1" curvedir="above" />
                   </measure>
-                  <measure xml:id="m8cav4y" n="5">
-                     <staff xml:id="m5s1" n="1">
-                        <layer xml:id="m5s1l1" n="1">
-                           <rest xml:id="rgk1zrw" dur="4" />
-                           <rest xml:id="r1h0hpvr" dur="8" />
-                           <rest xml:id="r1pjtsnu" dur="4" />
-                           <note xml:id="n1m30tjy" dur="8" pname="b" oct="3" stem.dir="up">
+                  <measure n="5">
+                     <staff n="1">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <note dur="8" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
                         </layer>
                      </staff>
-                     <staff xml:id="m5s2" n="2">
-                        <layer xml:id="m5s2l1" n="1">
+                     <staff n="2">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="nkl9nz0" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="nugsqrg" dur="8" pname="d" oct="5" stem.dir="down" />
-                              <note xml:id="n1y11ngj" dur="8" pname="e" oct="5" stem.dir="down">
-                                 <accid accid="f" />
-                              </note>
-                           </beam>
-                           <note xml:id="n1yzy165" dur="4" pname="d" oct="5" stem.dir="down" />
-                           <note xml:id="n16zs73o" dur="8" pname="b" oct="3" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                        </layer>
-                     </staff>
-                     <staff xml:id="m5s3" n="3">
-                        <layer xml:id="m5s3l1" n="1">
-                           <beam>
-                              <note xml:id="n13irxuw" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n1eum5ti" dur="8" pname="b" oct="4" stem.dir="down">
-                                 <accid accid="f" />
-                              </note>
-                              <note xml:id="n1nv1pwa" dur="8" pname="c" oct="5" stem.dir="down" />
-                           </beam>
-                           <note xml:id="ngpqhpp" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <note xml:id="n19epkxp" dur="8" pname="b" oct="3" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                        </layer>
-                     </staff>
-                     <staff xml:id="m5s4" n="4">
-                        <layer xml:id="m5s4l1" n="1">
-                           <beam>
-                              <note xml:id="nzeko3y" dur="8" pname="f" oct="3" stem.dir="down" />
-                              <note xml:id="n1mnbnna" dur="8" pname="f" oct="3" stem.dir="down" />
-                              <note xml:id="nth0zt2" dur="8" pname="f" oct="3" stem.dir="down" />
-                           </beam>
-                           <note xml:id="n1nft415" dur="4" pname="b" oct="2" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n1oqkvme" dur="8" pname="b" oct="2" stem.dir="up">
-                              <accid accid.ges="f" />
-                           </note>
-                        </layer>
-                     </staff>
-                     <slur xml:id="s166ody4" startid="#nkl9nz0" curvedir="above" endid="#n1y11ngj" />
-                     <slur xml:id="s19n0d9v" startid="#n13irxuw" curvedir="above" endid="#n1nv1pwa" />
-                  </measure>
-                  <measure xml:id="mad2lii" n="6">
-                     <staff xml:id="m6s1" n="1">
-                        <layer xml:id="m6s1l1" n="1">
-                           <note xml:id="n1kprqc2" dur="4" pname="b" oct="3" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n6gngom" dur="8" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="nnm2i0v" dur="4" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="n137itj1" dur="8" pname="f" oct="4" stem.dir="up" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m6s2" n="2">
-                        <layer xml:id="m6s2l1" n="1">
-                           <note xml:id="nbz0erm" dur="4" pname="b" oct="3" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="nfrpfba" dur="8" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="n9qcyml" dur="4" pname="d" oct="4" stem.dir="up" />
-                           <note xml:id="n1lhp7ko" dur="8" pname="f" oct="4" stem.dir="up" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m6s3" n="3">
-                        <layer xml:id="m6s3l1" n="1">
-                           <note xml:id="n15rku6u" dur="4" pname="b" oct="3" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n455o7z" dur="8" pname="d" oct="4" stem.dir="down" />
-                           <note xml:id="nuoffbx" dur="4" pname="d" oct="4" stem.dir="down" />
-                           <note xml:id="n6hvtqh" dur="8" pname="f" oct="4" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m6s4" n="4">
-                        <layer xml:id="m6s4l1" n="1">
-                           <note xml:id="nga1bdk" dur="4" pname="b" oct="2" stem.dir="up">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n1vx277w" dur="8" pname="d" oct="3" stem.dir="down" />
-                           <note xml:id="nfmyvqp" dur="4" pname="d" oct="3" stem.dir="down" />
-                           <note xml:id="nij8jop" dur="8" pname="f" oct="3" stem.dir="down" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure xml:id="m19xzai1" n="7">
-                     <staff xml:id="m7s1" n="1">
-                        <layer xml:id="m7s1l1" n="1">
-                           <note xml:id="nljbo90" dur="4" pname="f" oct="4" stem.dir="up" />
-                           <note xml:id="nmillrp" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="nigqsk8" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <note xml:id="n1q6uwk5" dur="8" pname="b" oct="4">
-                              <accid accid.ges="f" />
-                           </note>
-                        </layer>
-                     </staff>
-                     <staff xml:id="m7s2" n="2">
-                        <layer xml:id="m7s2l1" n="1">
-                           <note xml:id="n1y0t3rg" dur="4" pname="f" oct="4" stem.dir="up" />
-                           <note xml:id="n12tyoa8" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n1ns0bnz" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <note xml:id="n1fdliep" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                        </layer>
-                     </staff>
-                     <staff xml:id="m7s3" n="3">
-                        <layer xml:id="m7s3l1" n="1">
-                           <note xml:id="nzbcp0a" dur="4" pname="f" oct="4" stem.dir="down" />
-                           <note xml:id="n3z5adt" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n183o8sw" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <rest xml:id="rvymm39" dur="8" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m7s4" n="4">
-                        <layer xml:id="m7s4l1" n="1">
-                           <note xml:id="n1ef3k9w" dur="4" pname="f" oct="3" stem.dir="down" />
-                           <note xml:id="n1tn9qee" dur="8" pname="b" oct="3" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n1vtpa1a" dur="4" pname="b" oct="3" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <rest xml:id="r7glwp1" dur="8" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure xml:id="mgrtgk5" n="8">
-                     <staff xml:id="m8s1" n="1">
-                        <layer xml:id="m8s1l1" n="1">
-                           <beam>
-                              <note xml:id="n74sf0p" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="n185717e" dur="8" pname="f" oct="5" stem.dir="down" />
-                              <note xml:id="n15gtsrb" dur="8" pname="d" oct="5" stem.dir="down">
-                                 <artic xml:id="angz3no" artic="stacc" place="above" />
-                              </note>
-                           </beam>
-                           <note xml:id="neu6elj" dur="4" pname="c" oct="5" stem.dir="down" />
-                           <rest xml:id="r1fb5jft" dur="8" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m8s2" n="2">
-                        <layer xml:id="m8s2l1" n="1">
-                           <note xml:id="nhx3nw9" dur="4" pname="a" oct="4" stem.dir="up" />
-                           <note xml:id="n17m5q2q" dur="8" pname="b" oct="4" stem.dir="down">
-                              <accid accid="f" />
-                           </note>
-                           <note xml:id="n17qqlkl" dur="4" pname="a" oct="4" stem.dir="up" />
-                           <note xml:id="n1i3hnws" dur="8" pname="c" oct="5" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m8s3" n="3">
-                        <layer xml:id="m8s3l1" n="1">
-                           <rest xml:id="r1sf29v1" dur="4" />
-                           <rest xml:id="rjvr0w6" dur="8" />
-                           <rest xml:id="r13jvc4o" dur="4" />
-                           <note xml:id="n6hvlx0" dur="8" pname="a" oct="4" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m8s4" n="4">
-                        <layer xml:id="m8s4l1" n="1">
-                           <rest xml:id="r1gih5j5" dur="4" />
-                           <rest xml:id="raqqf80" dur="8" />
-                           <rest xml:id="r1t7b6lh" dur="4" />
-                           <note xml:id="nhvw8x7" dur="8" pname="f" oct="3" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <slur xml:id="siob87f" startid="#n74sf0p" curvedir="above" endid="#n185717e" />
-                  </measure>
-                  <measure xml:id="mehtskf" n="9">
-                     <staff xml:id="m9s1" n="1">
-                        <layer xml:id="m9s1l1" n="1">
-                           <rest xml:id="rst8ctg" dur="4" />
-                           <rest xml:id="r1x8xx44" dur="8" />
-                           <rest xml:id="rpk5vlk" dur="4" />
-                           <note xml:id="n11tidem" dur="8" pname="d" oct="5" stem.dir="down" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m9s2" n="2">
-                        <layer xml:id="m9s2l1" n="1">
-                           <beam>
-                              <note xml:id="n182by3y" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="n1f6wcnl" dur="8" pname="d" oct="5" stem.dir="down" />
-                              <note xml:id="n1k87xqm" dur="8" pname="e" oct="5" stem.dir="down">
+                              <note xml:id="nkl9nz0" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note dur="8" oct="5" pname="d" stem.dir="down" />
+                              <note xml:id="n1y11ngj" dur="8" oct="5" pname="e" stem.dir="down">
                                  <accid accid="f" />
                               </note>
                            </beam>
-                           <note xml:id="n1wjwxmm" dur="4" pname="d" oct="5" stem.dir="down" />
-                           <rest xml:id="riqrajz" dur="8" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m9s3" n="3">
-                        <layer xml:id="m9s3l1" n="1">
-                           <beam>
-                              <note xml:id="n1gipp2g" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n1stokzg" dur="8" pname="b" oct="4" stem.dir="down">
-                                 <accid accid="f" />
-                              </note>
-                              <note xml:id="n1052e3" dur="8" pname="c" oct="5" stem.dir="down" />
-                           </beam>
-                           <note xml:id="n3n759m" dur="4" pname="b" oct="4" stem.dir="down">
-                              <accid accid.ges="f" />
-                           </note>
-                           <rest xml:id="rsnwec1" dur="8" />
-                        </layer>
-                     </staff>
-                     <staff xml:id="m9s4" n="4">
-                        <layer xml:id="m9s4l1" n="1">
-                           <beam>
-                              <note xml:id="n1u6qiwt" dur="8" pname="f" oct="3" stem.dir="down" />
-                              <note xml:id="n7yjz5s" dur="8" pname="f" oct="3" stem.dir="down" />
-                              <note xml:id="n1dwn2e4" dur="8" pname="f" oct="3" stem.dir="down" />
-                           </beam>
-                           <note xml:id="nw5vjoi" dur="4" pname="b" oct="2" stem.dir="up">
+                           <note dur="4" oct="5" pname="d" stem.dir="down" />
+                           <note dur="8" oct="3" pname="b" stem.dir="up">
                               <accid accid="f" />
                            </note>
-                           <rest xml:id="r1yip3ww" dur="8" />
                         </layer>
                      </staff>
-                     <slur xml:id="sa6itin" startid="#n182by3y" curvedir="above" endid="#n1k87xqm" />
-                     <slur xml:id="s1i54mz1" startid="#n1gipp2g" curvedir="above" endid="#n1052e3" />
-                  </measure>
-                  <measure xml:id="mn1j7gs" n="10">
-                     <staff xml:id="m10s1" n="1">
-                        <layer xml:id="m10s1l1" n="1">
+                     <staff n="3">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1e85t27" dur="8" pname="b" oct="5" stem.dir="down">
+                              <note xml:id="n13irxuw" dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note dur="8" oct="4" pname="b" stem.dir="down">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="nisagdl" dur="8" pname="g" oct="5" stem.dir="down" />
-                              <note xml:id="n157w330" dur="8" pname="e" oct="5" stem.dir="down">
-                                 <artic xml:id="a1kkdwdy" artic="stacc" place="above" />
+                              <note xml:id="n1nv1pwa" dur="8" oct="5" pname="c" stem.dir="down" />
+                           </beam>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <note dur="8" oct="3" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
+                           </beam>
+                           <note dur="4" oct="2" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="8" oct="2" pname="b" stem.dir="up">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <slur startid="#nkl9nz0" endid="#n1y11ngj" curvedir="above" />
+                     <slur startid="#n13irxuw" endid="#n1nv1pwa" curvedir="above" />
+                  </measure>
+                  <measure n="6">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="8" oct="4" pname="d" stem.dir="up" />
+                           <note dur="4" oct="4" pname="d" stem.dir="up" />
+                           <note dur="8" oct="4" pname="f" stem.dir="up" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="8" oct="4" pname="d" stem.dir="up" />
+                           <note dur="4" oct="4" pname="d" stem.dir="up" />
+                           <note dur="8" oct="4" pname="f" stem.dir="up" />
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="8" oct="4" pname="d" stem.dir="down" />
+                           <note dur="4" oct="4" pname="d" stem.dir="down" />
+                           <note dur="8" oct="4" pname="f" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <note dur="4" oct="2" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="8" oct="3" pname="d" stem.dir="down" />
+                           <note dur="4" oct="3" pname="d" stem.dir="down" />
+                           <note dur="8" oct="3" pname="f" stem.dir="down" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="7">
+                     <staff n="1">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="up" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <note dur="8" oct="4" pname="b">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="up" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="down" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="f" stem.dir="down" />
+                           <note dur="8" oct="3" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="3" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="8">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="n74sf0p" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note xml:id="n185717e" dur="8" oct="5" pname="f" stem.dir="down" />
+                              <note dur="8" oct="5" pname="d" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
+                              </note>
+                           </beam>
+                           <note dur="4" oct="5" pname="c" stem.dir="down" />
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="a" stem.dir="up" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <accid accid="f" />
+                           </note>
+                           <note dur="4" oct="4" pname="a" stem.dir="up" />
+                           <note dur="8" oct="5" pname="c" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <note dur="8" oct="4" pname="a" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <note dur="8" oct="3" pname="f" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <slur startid="#n74sf0p" endid="#n185717e" curvedir="above" />
+                  </measure>
+                  <measure n="9">
+                     <staff n="1">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <note dur="8" oct="5" pname="d" stem.dir="down" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="n182by3y" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note dur="8" oct="5" pname="d" stem.dir="down" />
+                              <note xml:id="n1k87xqm" dur="8" oct="5" pname="e" stem.dir="down">
+                                 <accid accid="f" />
+                              </note>
+                           </beam>
+                           <note dur="4" oct="5" pname="d" stem.dir="down" />
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="n1gipp2g" dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note dur="8" oct="4" pname="b" stem.dir="down">
+                                 <accid accid="f" />
+                              </note>
+                              <note xml:id="n1052e3" dur="8" oct="5" pname="c" stem.dir="down" />
+                           </beam>
+                           <note dur="4" oct="4" pname="b" stem.dir="down">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
+                           </beam>
+                           <note dur="4" oct="2" pname="b" stem.dir="up">
+                              <accid accid="f" />
+                           </note>
+                           <rest dur="8" />
+                        </layer>
+                     </staff>
+                     <slur startid="#n182by3y" endid="#n1k87xqm" curvedir="above" />
+                     <slur startid="#n1gipp2g" endid="#n1052e3" curvedir="above" />
+                  </measure>
+                  <measure n="10">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="n1e85t27" dur="8" oct="5" pname="b" stem.dir="down">
+                                 <accid accid="f" />
+                              </note>
+                              <note xml:id="nisagdl" dur="8" oct="5" pname="g" stem.dir="down" />
+                              <note dur="8" oct="5" pname="e" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                                  <accid accid="n" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n1qklwrg" dur="8" pname="f" oct="5" stem.dir="down" />
-                              <note xml:id="nz7mbjg" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="n1bn16sr" dur="8" pname="c" oct="5" stem.dir="down">
-                                 <artic xml:id="aa60irm" artic="stacc" place="above" />
+                              <note xml:id="n1qklwrg" dur="8" oct="5" pname="f" stem.dir="down" />
+                              <note xml:id="nz7mbjg" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note dur="8" oct="5" pname="c" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m10s2" n="2">
-                        <layer xml:id="m10s2l1" n="1">
+                     <staff n="2">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1azs36f" dur="8" pname="d" oct="5" stem.dir="up" />
-                              <note xml:id="n1u9ikos" dur="8" pname="b" oct="4" stem.dir="up">
+                              <note dur="8" oct="5" pname="d" stem.dir="up" />
+                              <note dur="8" oct="4" pname="b" stem.dir="up">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n1y7psk5" dur="8" pname="g" oct="4" stem.dir="up">
-                                 <artic xml:id="aevi2m3" artic="stacc" place="below" />
+                              <note dur="8" oct="4" pname="g" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n14hmf3z" dur="8" pname="f" oct="4" stem.dir="up" />
-                              <note xml:id="n4iephj" dur="8" pname="a" oct="4" stem.dir="up" />
+                              <note xml:id="n14hmf3z" dur="8" oct="4" pname="f" stem.dir="up" />
+                              <note xml:id="n4iephj" dur="8" oct="4" pname="a" stem.dir="up" />
                            </beam>
-                           <rest xml:id="rm2d2mj" dur="8" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m10s3" n="3">
-                        <layer xml:id="m10s3l1" n="1">
-                           <rest xml:id="r1di9g8n" dur="4" />
-                           <note xml:id="nhpw687" dur="8" pname="b" oct="4" stem.dir="down">
-                              <artic xml:id="ai173a1" artic="stacc" place="above" />
+                     <staff n="3">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <note dur="8" oct="4" pname="b" stem.dir="down">
+                              <artic artic="stacc" place="above" />
                               <accid accid="f" />
                            </note>
                            <beam>
-                              <note xml:id="n1s69l33" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n1ccj2e3" dur="8" pname="f" oct="4" stem.dir="down" />
+                              <note xml:id="n1s69l33" dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note xml:id="n1ccj2e3" dur="8" oct="4" pname="f" stem.dir="down" />
                            </beam>
-                           <rest xml:id="r1t4i14v" dur="8" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m10s4" n="4">
-                        <layer xml:id="m10s4l1" n="1">
-                           <rest xml:id="r1pxwsps" dur="8" />
-                           <rest xml:id="r1bu1glu" dur="8" />
-                           <note xml:id="n108hbcy" dur="8" pname="c" oct="4" stem.dir="down">
-                              <artic xml:id="a1vi36pv" artic="stacc" place="above" />
+                     <staff n="4">
+                        <layer n="1">
+                           <rest dur="8" />
+                           <rest dur="8" />
+                           <note dur="8" oct="4" pname="c" stem.dir="down">
+                              <artic artic="stacc" place="above" />
                            </note>
                            <beam>
-                              <note xml:id="n48z2x8" dur="8" pname="a" oct="3" stem.dir="down" />
-                              <note xml:id="nvw5svr" dur="8" pname="f" oct="3" stem.dir="down" />
+                              <note xml:id="n48z2x8" dur="8" oct="3" pname="a" stem.dir="down" />
+                              <note xml:id="nvw5svr" dur="8" oct="3" pname="f" stem.dir="down" />
                            </beam>
-                           <rest xml:id="r7e7ynv" dur="8" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <slur xml:id="s3h83cd" startid="#n1e85t27" curvedir="above" endid="#nisagdl" />
-                     <slur xml:id="s1uzg5n5" startid="#n1qklwrg" curvedir="above" endid="#nz7mbjg" />
-                     <slur xml:id="sx5t1m" startid="#n14hmf3z" curvedir="below" endid="#n4iephj" />
-                     <slur xml:id="s1rj8viv" startid="#n1s69l33" curvedir="above" endid="#n1ccj2e3" />
-                     <slur xml:id="s1p7wkp6" startid="#n48z2x8" curvedir="above" endid="#nvw5svr" />
+                     <slur startid="#n1e85t27" endid="#nisagdl" curvedir="above" />
+                     <slur startid="#n1qklwrg" endid="#nz7mbjg" curvedir="above" />
+                     <slur startid="#n14hmf3z" endid="#n4iephj" curvedir="below" />
+                     <slur startid="#n1s69l33" endid="#n1ccj2e3" curvedir="above" />
+                     <slur startid="#n48z2x8" endid="#nvw5svr" curvedir="above" />
                   </measure>
-                  <measure xml:id="m15v34fd" n="11">
-                     <staff xml:id="m11s1" n="1">
-                        <layer xml:id="m11s1l1" n="1">
+                  <measure n="11">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n6ztcp5" dur="8" pname="g" oct="5" stem.dir="down" />
-                              <note xml:id="nv2wppe" dur="8" pname="e" oct="5" stem.dir="down">
+                              <note xml:id="n6ztcp5" dur="8" oct="5" pname="g" stem.dir="down" />
+                              <note xml:id="nv2wppe" dur="8" oct="5" pname="e" stem.dir="down">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="ngz16dk" dur="8" pname="b" oct="4" stem.dir="down">
-                                 <artic xml:id="ay2um55" artic="stacc" place="above" />
+                              <note dur="8" oct="4" pname="b" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                                  <accid accid="f" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n1eqp9pu" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n1xvhx1s" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="n12z7so0" dur="8" pname="c" oct="5" stem.dir="down">
-                                 <artic xml:id="aax910y" artic="stacc" place="above" />
+                              <note xml:id="n1eqp9pu" dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note xml:id="n1xvhx1s" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note dur="8" oct="5" pname="c" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m11s2" n="2">
-                        <layer xml:id="m11s2l1" n="1">
+                     <staff n="2">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n11zjoib" dur="8" pname="b" oct="4" stem.dir="up">
+                              <note xml:id="n11zjoib" dur="8" oct="4" pname="b" stem.dir="up">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n1vrj2z9" dur="8" pname="g" oct="4" stem.dir="up" />
-                              <note xml:id="nwm7p2c" dur="8" pname="e" oct="4" stem.dir="up">
-                                 <artic xml:id="a5t4r1t" artic="stacc" place="below" />
+                              <note xml:id="n1vrj2z9" dur="8" oct="4" pname="g" stem.dir="up" />
+                              <note dur="8" oct="4" pname="e" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                                  <accid accid="n" />
                               </note>
                            </beam>
-                           <note xml:id="n5jtl3c" dur="4" pname="f" oct="4" stem.dir="up" />
-                           <rest xml:id="rfddxeo" dur="8" />
+                           <note dur="4" oct="4" pname="f" stem.dir="up" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m11s3" n="3">
-                        <layer xml:id="m11s3l1" n="1">
-                           <rest xml:id="r2yr8n" dur="4" />
-                           <note xml:id="nfzax4y" dur="8" pname="g" oct="4" stem.dir="down">
-                              <artic xml:id="accwcjh" artic="stacc" place="above" />
+                     <staff n="3">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <note dur="8" oct="4" pname="g" stem.dir="down">
+                              <artic artic="stacc" place="above" />
                            </note>
                            <beam>
-                              <note xml:id="n4mryey" dur="8" pname="f" oct="4" stem.dir="down" />
-                              <note xml:id="naujqjg" dur="8" pname="a" oct="4" stem.dir="down" />
+                              <note xml:id="n4mryey" dur="8" oct="4" pname="f" stem.dir="down" />
+                              <note xml:id="naujqjg" dur="8" oct="4" pname="a" stem.dir="down" />
                            </beam>
-                           <rest xml:id="r178riuw" dur="8" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m11s4" n="4">
-                        <layer xml:id="m11s4l1" n="1">
-                           <rest xml:id="r1l4r8i0" dur="8" />
-                           <rest xml:id="ryy5pci" dur="8" />
-                           <note xml:id="ntl2bew" dur="8" pname="c" oct="3" stem.dir="up">
-                              <artic xml:id="a134cok1" artic="stacc" place="below" />
+                     <staff n="4">
+                        <layer n="1">
+                           <rest dur="8" />
+                           <rest dur="8" />
+                           <note dur="8" oct="3" pname="c" stem.dir="up">
+                              <artic artic="stacc" place="below" />
                            </note>
                            <beam>
-                              <note xml:id="n9r0gct" dur="8" pname="f" oct="3" stem.dir="down" />
-                              <note xml:id="n170ocob" dur="8" pname="a" oct="3" stem.dir="down" />
+                              <note xml:id="n9r0gct" dur="8" oct="3" pname="f" stem.dir="down" />
+                              <note xml:id="n170ocob" dur="8" oct="3" pname="a" stem.dir="down" />
                            </beam>
-                           <rest xml:id="r1362k56" dur="8" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <slur xml:id="sm73ets" startid="#n6ztcp5" curvedir="above" endid="#nv2wppe" />
-                     <slur xml:id="s2u01hd" startid="#n1eqp9pu" curvedir="above" endid="#n1xvhx1s" />
-                     <slur xml:id="sqetedk" startid="#n11zjoib" curvedir="below" endid="#n1vrj2z9" />
-                     <slur xml:id="s1nrxyq5" startid="#n4mryey" curvedir="above" endid="#naujqjg" />
-                     <slur xml:id="s19yn9lv" startid="#n9r0gct" curvedir="above" endid="#n170ocob" />
+                     <slur startid="#n6ztcp5" endid="#nv2wppe" curvedir="above" />
+                     <slur startid="#n1eqp9pu" endid="#n1xvhx1s" curvedir="above" />
+                     <slur startid="#n11zjoib" endid="#n1vrj2z9" curvedir="below" />
+                     <slur startid="#n4mryey" endid="#naujqjg" curvedir="above" />
+                     <slur startid="#n9r0gct" endid="#n170ocob" curvedir="above" />
                   </measure>
-                  <measure xml:id="m4iyefk" n="12">
-                     <staff xml:id="m12s1" n="1">
-                        <layer xml:id="m12s1l1" n="1">
+                  <measure n="12">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="nipzm8z" dur="8" pname="d" oct="5" stem.dir="down" />
-                              <note xml:id="n16wgi7t" dur="8" pname="b" oct="4" stem.dir="down">
+                              <note xml:id="nipzm8z" dur="8" oct="5" pname="d" stem.dir="down" />
+                              <note xml:id="n16wgi7t" dur="8" oct="4" pname="b" stem.dir="down">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n10ob44w" dur="8" pname="g" oct="4" stem.dir="down">
-                                 <artic xml:id="a1nd86ny" artic="stacc" place="above" />
+                              <note dur="8" oct="4" pname="g" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n1mu8nsh" dur="8" pname="c" oct="5" stem.dir="up" />
-                              <note xml:id="n1bq8z1h" dur="8" pname="a" oct="4" stem.dir="up" />
-                              <note xml:id="n1e0jsbx" dur="8" pname="f" oct="4" stem.dir="up">
-                                 <artic xml:id="a37y7tp" artic="stacc" place="below" />
+                              <note xml:id="n1mu8nsh" dur="8" oct="5" pname="c" stem.dir="up" />
+                              <note xml:id="n1bq8z1h" dur="8" oct="4" pname="a" stem.dir="up" />
+                              <note dur="8" oct="4" pname="f" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m12s2" n="2">
-                        <layer xml:id="m12s2l1" n="1">
+                     <staff n="2">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1yar5qn" dur="8" pname="d" oct="4" stem.dir="up" />
-                              <note xml:id="nv7s2gb" dur="8" pname="g" oct="4" stem.dir="up" />
-                              <note xml:id="nxcun8t" dur="8" pname="b" oct="4" stem.dir="up">
-                                 <artic xml:id="agdqz06" artic="stacc" place="below" />
+                              <note xml:id="n1yar5qn" dur="8" oct="4" pname="d" stem.dir="up" />
+                              <note xml:id="nv7s2gb" dur="8" oct="4" pname="g" stem.dir="up" />
+                              <note dur="8" oct="4" pname="b" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                                  <accid accid="f" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n47iyau" dur="8" pname="b" oct="3" stem.dir="up">
+                              <note xml:id="n47iyau" dur="8" oct="3" pname="b" stem.dir="up">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n19bqy33" dur="8" pname="e" oct="4" stem.dir="up">
+                              <note xml:id="n19bqy33" dur="8" oct="4" pname="e" stem.dir="up">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="n192auuy" dur="8" pname="e" oct="4" stem.dir="up">
-                                 <artic xml:id="ayx2lqy" artic="stacc" place="below" />
+                              <note dur="8" oct="4" pname="e" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m12s3" n="3">
-                        <layer xml:id="m12s3l1" n="1">
-                           <note xml:id="nwmzg31" dots="1" dur="4" pname="b" oct="4" stem.dir="down">
+                     <staff n="3">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="4" pname="b" stem.dir="down">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="nr47hmy" dots="1" dur="4" pname="a" oct="4" stem.dir="down" />
+                           <note dots="1" dur="4" oct="4" pname="a" stem.dir="down" />
                         </layer>
                      </staff>
-                     <staff xml:id="m12s4" n="4">
-                        <layer xml:id="m12s4l1" n="1">
-                           <note xml:id="nfv59vg" dots="1" dur="4" pname="b" oct="3" stem.dir="down">
+                     <staff n="4">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="3" pname="b" stem.dir="down">
                               <accid accid="f" />
                            </note>
-                           <note xml:id="nskwnql" dots="1" dur="4" pname="a" oct="3" stem.dir="down" />
+                           <note dots="1" dur="4" oct="3" pname="a" stem.dir="down" />
                         </layer>
                      </staff>
-                     <slur xml:id="s11l1ogr" startid="#nipzm8z" curvedir="above" endid="#n16wgi7t" />
-                     <slur xml:id="s2ipoxj" startid="#n1mu8nsh" curvedir="below" endid="#n1bq8z1h" />
-                     <slur xml:id="s1v5ds1i" startid="#n1yar5qn" curvedir="below" endid="#nv7s2gb" />
-                     <slur xml:id="s1ea4211" startid="#n47iyau" curvedir="below" endid="#n19bqy33" />
+                     <slur startid="#nipzm8z" endid="#n16wgi7t" curvedir="above" />
+                     <slur startid="#n1mu8nsh" endid="#n1bq8z1h" curvedir="below" />
+                     <slur startid="#n1yar5qn" endid="#nv7s2gb" curvedir="below" />
+                     <slur startid="#n47iyau" endid="#n19bqy33" curvedir="below" />
                   </measure>
-                  <measure xml:id="m1p082wb" n="13">
-                     <staff xml:id="m13s1" n="1">
-                        <layer xml:id="m13s1l1" n="1">
+                  <measure n="13">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1hzvaiv" dur="8" pname="e" oct="4" stem.dir="up">
+                              <note xml:id="n1hzvaiv" dur="8" oct="4" pname="e" stem.dir="up">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="nl6k2jh" dur="8" pname="b" oct="4" stem.dir="up">
+                              <note xml:id="nl6k2jh" dur="8" oct="4" pname="b" stem.dir="up">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n1791j8e" dur="8" pname="b" oct="4" stem.dir="up">
-                                 <artic xml:id="ae0xonj" artic="stacc" place="below" />
+                              <note dur="8" oct="4" pname="b" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                                  <accid accid.ges="f" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="nfukl6x" dur="8" pname="b" oct="4" stem.dir="down">
+                              <note xml:id="nfukl6x" dur="8" oct="4" pname="b" stem.dir="down">
                                  <accid accid.ges="f" />
                               </note>
-                              <note xml:id="n15y3m8v" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n11plx2c" dur="8" pname="c" oct="5" stem.dir="down">
-                                 <artic xml:id="a1uu1ne9" artic="stacc" place="above" />
+                              <note xml:id="n15y3m8v" dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note dur="8" oct="5" pname="c" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m13s2" n="2">
-                        <layer xml:id="m13s2l1" n="1">
-                           <note xml:id="n1w7tof8" dur="4" pname="f" oct="4" stem.dir="up" />
-                           <rest xml:id="r1wifcrg" dur="8" />
-                           <rest xml:id="rmrjg4h" dur="4" />
-                           <rest xml:id="r1txe30r" dur="8" />
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="f" stem.dir="up" />
+                           <rest dur="8" />
+                           <rest dur="4" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m13s3" n="3">
-                        <layer xml:id="m13s3l1" n="1">
-                           <note xml:id="n3llih8" dur="4" pname="g" oct="4" stem.dir="down" />
-                           <note xml:id="nrvo8q1" dur="8" pname="c" oct="4" stem.dir="down" />
-                           <note xml:id="nsbuj1t" dur="4" pname="f" oct="4" stem.dir="down" />
-                           <rest xml:id="r17ttxtd" dur="8" />
+                     <staff n="3">
+                        <layer n="1">
+                           <note dur="4" oct="4" pname="g" stem.dir="down" />
+                           <note dur="8" oct="4" pname="c" stem.dir="down" />
+                           <note dur="4" oct="4" pname="f" stem.dir="down" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m13s4" n="4">
-                        <layer xml:id="m13s4l1" n="1">
-                           <note xml:id="nf0tsez" dur="4" pname="g" oct="3" stem.dir="down" />
-                           <note xml:id="n1knx921" dur="8" pname="c" oct="3" stem.dir="up" />
-                           <note xml:id="n17upykd" dur="4" pname="f" oct="3" stem.dir="down" />
-                           <rest xml:id="rr3bi65" dur="8" />
+                     <staff n="4">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="g" stem.dir="down" />
+                           <note dur="8" oct="3" pname="c" stem.dir="up" />
+                           <note dur="4" oct="3" pname="f" stem.dir="down" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <slur xml:id="s17mvx0c" startid="#n1hzvaiv" curvedir="below" endid="#nl6k2jh" />
-                     <slur xml:id="szmwrg0" startid="#nfukl6x" curvedir="above" endid="#n15y3m8v" />
+                     <slur startid="#n1hzvaiv" endid="#nl6k2jh" curvedir="below" />
+                     <slur startid="#nfukl6x" endid="#n15y3m8v" curvedir="above" />
                   </measure>
-                  <measure xml:id="m1b7bch4" n="14">
-                     <staff xml:id="m14s1" n="1">
-                        <layer xml:id="m14s1l1" n="1">
+                  <measure n="14">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="ntzl71g" dur="8" pname="b" oct="5" stem.dir="down">
+                              <note xml:id="ntzl71g" dur="8" oct="5" pname="b" stem.dir="down">
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n11pqwin" dur="8" pname="g" oct="5" stem.dir="down" />
-                              <note xml:id="n58hina" dur="8" pname="e" oct="5" stem.dir="down">
-                                 <artic xml:id="a10odkuy" artic="stacc" place="above" />
+                              <note xml:id="n11pqwin" dur="8" oct="5" pname="g" stem.dir="down" />
+                              <note dur="8" oct="5" pname="e" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                                  <accid accid="n" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n1ggqyho" dur="8" pname="f" oct="5" stem.dir="down" />
-                              <note xml:id="n1ryjebo" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="not8a7u" dur="8" pname="c" oct="5" stem.dir="down">
-                                 <artic xml:id="a1y7ua6p" artic="stacc" place="above" />
+                              <note xml:id="n1ggqyho" dur="8" oct="5" pname="f" stem.dir="down" />
+                              <note xml:id="n1ryjebo" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note dur="8" oct="5" pname="c" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m14s2" n="2">
-                        <layer xml:id="m14s2l1" n="1">
-                           <rest xml:id="r1dllpdm" dur="4" />
-                           <rest xml:id="rowipax" dur="8" />
+                     <staff n="2">
+                        <layer n="1">
+                           <rest dur="4" />
+                           <rest dur="8" />
                            <beam>
-                              <note xml:id="n9b5ohv" dur="8" pname="c" oct="4" stem.dir="up" />
-                              <note xml:id="nf5q9a5" dur="8" pname="e" oct="4" stem.dir="up">
+                              <note xml:id="n9b5ohv" dur="8" oct="4" pname="c" stem.dir="up" />
+                              <note xml:id="nf5q9a5" dur="8" oct="4" pname="e" stem.dir="up">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="n1f6fc7t" dur="8" pname="f" oct="4" stem.dir="up">
-                                 <artic xml:id="ahfltpb" artic="stacc" place="below" />
+                              <note dur="8" oct="4" pname="f" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m14s3" n="3">
-                        <layer xml:id="m14s3l1" n="1">
-                           <note xml:id="n1sshii6" dots="1" dur="4" pname="g" oct="4" stem.dir="down" />
+                     <staff n="3">
+                        <layer n="1">
+                           <note dots="1" dur="4" oct="4" pname="g" stem.dir="down" />
                            <beam>
-                              <note xml:id="n1fypkvx" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n180klpc" dur="8" pname="g" oct="4" stem.dir="down" />
-                              <note xml:id="n1vbo5io" dur="8" pname="f" oct="4" stem.dir="down" />
+                              <note dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note dur="8" oct="4" pname="g" stem.dir="down" />
+                              <note dur="8" oct="4" pname="f" stem.dir="down" />
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m14s4" n="4">
-                        <layer xml:id="m14s4l1" n="1">
+                     <staff n="4">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1t113k5" dur="8" pname="c" oct="3" stem.dir="down" />
-                              <note xml:id="n10q0odr" dur="8" pname="c" oct="4" stem.dir="down" />
-                              <note xml:id="n1pku89v" dur="8" pname="b" oct="3" stem.dir="down">
+                              <note dur="8" oct="3" pname="c" stem.dir="down" />
+                              <note dur="8" oct="4" pname="c" stem.dir="down" />
+                              <note dur="8" oct="3" pname="b" stem.dir="down">
                                  <accid accid="f" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="nq8g71w" dur="8" pname="a" oct="3" stem.dir="down" />
-                              <note xml:id="n124slbq" dur="8" pname="g" oct="3" stem.dir="down" />
-                              <note xml:id="n15zm555" dur="8" pname="f" oct="3" stem.dir="down" />
+                              <note dur="8" oct="3" pname="a" stem.dir="down" />
+                              <note dur="8" oct="3" pname="g" stem.dir="down" />
+                              <note dur="8" oct="3" pname="f" stem.dir="down" />
                            </beam>
                         </layer>
                      </staff>
-                     <slur xml:id="so2pfhr" startid="#ntzl71g" curvedir="above" endid="#n11pqwin" />
-                     <slur xml:id="sqgja7y" startid="#n1ggqyho" curvedir="above" endid="#n1ryjebo" />
-                     <slur xml:id="sm2j1ny" startid="#n9b5ohv" curvedir="below" endid="#nf5q9a5" />
+                     <slur startid="#ntzl71g" endid="#n11pqwin" curvedir="above" />
+                     <slur startid="#n1ggqyho" endid="#n1ryjebo" curvedir="above" />
+                     <slur startid="#n9b5ohv" endid="#nf5q9a5" curvedir="below" />
                   </measure>
-                  <measure xml:id="mo8sku5" n="15">
-                     <staff xml:id="m15s1" n="1">
-                        <layer xml:id="m15s1l1" n="1">
+                  <measure n="15">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="ng5k7jm" dur="8" pname="g" oct="5" stem.dir="down" />
-                              <note xml:id="nid0bu8" dur="8" pname="e" oct="5" stem.dir="down">
+                              <note xml:id="ng5k7jm" dur="8" oct="5" pname="g" stem.dir="down" />
+                              <note xml:id="nid0bu8" dur="8" oct="5" pname="e" stem.dir="down">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="n50c3eu" dur="8" pname="b" oct="4" stem.dir="down">
-                                 <artic xml:id="auo1a6k" artic="stacc" place="above" />
+                              <note dur="8" oct="4" pname="b" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                                  <accid accid="f" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="nwag0d0" dur="8" pname="a" oct="4" stem.dir="down" />
-                              <note xml:id="n1icgi9w" dur="8" pname="c" oct="5" stem.dir="down" />
-                              <note xml:id="n1ftrofh" dur="8" pname="c" oct="5" stem.dir="down">
-                                 <artic xml:id="a1i4xded" artic="stacc" place="above" />
+                              <note xml:id="nwag0d0" dur="8" oct="4" pname="a" stem.dir="down" />
+                              <note xml:id="n1icgi9w" dur="8" oct="5" pname="c" stem.dir="down" />
+                              <note dur="8" oct="5" pname="c" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m15s2" n="2">
-                        <layer xml:id="m15s2l1" n="1">
+                     <staff n="2">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="nxdq8qd" dur="8" pname="c" oct="4" stem.dir="up" />
-                              <note xml:id="n1lv1sep" dur="8" pname="g" oct="4" stem.dir="up" />
-                              <note xml:id="n17ealrx" dur="8" pname="g" oct="4" stem.dir="up">
-                                 <artic xml:id="a1ib2lau" artic="stacc" place="below" />
+                              <note xml:id="nxdq8qd" dur="8" oct="4" pname="c" stem.dir="up" />
+                              <note xml:id="n1lv1sep" dur="8" oct="4" pname="g" stem.dir="up" />
+                              <note dur="8" oct="4" pname="g" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n1lopy3p" dur="8" pname="f" oct="4" stem.dir="up" />
-                              <note xml:id="nympimz" dur="8" pname="a" oct="4" stem.dir="up" />
-                              <note xml:id="nzrszxi" dur="8" pname="a" oct="4" stem.dir="up">
-                                 <artic xml:id="a1supkxa" artic="stacc" place="below" />
+                              <note xml:id="n1lopy3p" dur="8" oct="4" pname="f" stem.dir="up" />
+                              <note xml:id="nympimz" dur="8" oct="4" pname="a" stem.dir="up" />
+                              <note dur="8" oct="4" pname="a" stem.dir="up">
+                                 <artic artic="stacc" place="below" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m15s3" n="3">
-                        <layer xml:id="m15s3l1" n="1">
+                     <staff n="3">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n10i68bw" dur="8" pname="e" oct="4" stem.dir="down">
+                              <note dur="8" oct="4" pname="e" stem.dir="down">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="n85x6z6" dur="8" pname="c" oct="4" stem.dir="down" />
-                              <note xml:id="n16dz1wc" dur="8" pname="e" oct="4" stem.dir="down" />
+                              <note dur="8" oct="4" pname="c" stem.dir="down" />
+                              <note dur="8" oct="4" pname="e" stem.dir="down" />
                            </beam>
-                           <note xml:id="n1o2mh54" dur="4" pname="f" oct="4" stem.dir="down" />
-                           <rest xml:id="rm3qpto" dur="8" />
+                           <note dur="4" oct="4" pname="f" stem.dir="down" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <staff xml:id="m15s4" n="4">
-                        <layer xml:id="m15s4l1" n="1">
+                     <staff n="4">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="nur67ho" dur="8" pname="e" oct="3" stem.dir="down">
+                              <note dur="8" oct="3" pname="e" stem.dir="down">
                                  <accid accid="n" />
                               </note>
-                              <note xml:id="nj4xb4n" dur="8" pname="c" oct="3" stem.dir="down" />
-                              <note xml:id="n1hpl835" dur="8" pname="e" oct="3" stem.dir="down" />
+                              <note dur="8" oct="3" pname="c" stem.dir="down" />
+                              <note dur="8" oct="3" pname="e" stem.dir="down" />
                            </beam>
-                           <note xml:id="nivfp3k" dur="4" pname="f" oct="3" stem.dir="down" />
-                           <rest xml:id="rrux8h6" dur="8" />
+                           <note dur="4" oct="3" pname="f" stem.dir="down" />
+                           <rest dur="8" />
                         </layer>
                      </staff>
-                     <slur xml:id="s1u50xxx" startid="#ng5k7jm" curvedir="above" endid="#nid0bu8" />
-                     <slur xml:id="soh1mis" startid="#nwag0d0" curvedir="above" endid="#n1icgi9w" />
-                     <slur xml:id="su59k2h" startid="#nxdq8qd" curvedir="below" endid="#n1lv1sep" />
-                     <slur xml:id="s1lj2hdl" startid="#n1lopy3p" curvedir="below" endid="#nympimz" />
+                     <slur startid="#ng5k7jm" endid="#nid0bu8" curvedir="above" />
+                     <slur startid="#nwag0d0" endid="#n1icgi9w" curvedir="above" />
+                     <slur startid="#nxdq8qd" endid="#n1lv1sep" curvedir="below" />
+                     <slur startid="#n1lopy3p" endid="#nympimz" curvedir="below" />
                   </measure>
-                  <measure xml:id="m5xxesi" n="16">
-                     <staff xml:id="m16s1" n="1">
-                        <layer xml:id="m16s1l1" n="1">
+                  <measure n="16">
+                     <staff n="1">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="n1lz4cjo" dur="8" pname="d" oct="5" stem.dir="down">
-                                 <artic xml:id="a125ungz" artic="stacc" place="above" />
+                              <note dur="8" oct="5" pname="d" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
-                              <note xml:id="n1iedk6n" dur="8" pname="d" oct="5" stem.dir="down" />
-                              <note xml:id="nmgjzbp" dur="8" pname="e" oct="5" stem.dir="down">
+                              <note xml:id="n1iedk6n" dur="8" oct="5" pname="d" stem.dir="down" />
+                              <note xml:id="nmgjzbp" dur="8" oct="5" pname="e" stem.dir="down">
                                  <accid accid="n" />
                               </note>
                            </beam>
                            <beam>
-                              <note xml:id="n60rnqj" dur="8" pname="f" oct="5" stem.dir="down">
-                                 <artic xml:id="ao77bbs" artic="stacc" place="above" />
+                              <note dur="8" oct="5" pname="f" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
-                              <note xml:id="nbubu4b" dur="8" pname="f" oct="5" stem.dir="down" />
-                              <note xml:id="n1m4pb0s" dur="8" pname="g" oct="5" stem.dir="down" />
+                              <note xml:id="nbubu4b" dur="8" oct="5" pname="f" stem.dir="down" />
+                              <note xml:id="n1m4pb0s" dur="8" oct="5" pname="g" stem.dir="down" />
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m16s2" n="2">
-                        <layer xml:id="m16s2l1" n="1">
+                     <staff n="2">
+                        <layer n="1">
                            <beam>
-                              <note xml:id="nfc5tud" dur="8" pname="b" oct="4" stem.dir="down">
-                                 <artic xml:id="atikbcg" artic="stacc" place="above" />
+                              <note dur="8" oct="4" pname="b" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                                  <accid accid="f" />
                               </note>
-                              <note xml:id="n1yjdt6u" dur="8" pname="b" oct="4" stem.dir="down">
+                              <note xml:id="n1yjdt6u" dur="8" oct="4" pname="b" stem.dir="down">
                                  <accid accid.ges="f" />
                               </note>
-                              <note xml:id="nm1bw5w" dur="8" pname="c" oct="5" stem.dir="down" />
+                              <note xml:id="nm1bw5w" dur="8" oct="5" pname="c" stem.dir="down" />
                            </beam>
                            <beam>
-                              <note xml:id="nrlm8dk" dur="8" pname="d" oct="5" stem.dir="down">
-                                 <artic xml:id="aj5woz3" artic="stacc" place="above" />
+                              <note dur="8" oct="5" pname="d" stem.dir="down">
+                                 <artic artic="stacc" place="above" />
                               </note>
-                              <note xml:id="n11i8g6l" dur="8" pname="d" oct="5" stem.dir="down" />
-                              <note xml:id="nzij5rd" dur="8" pname="e" oct="5" stem.dir="down">
+                              <note xml:id="n11i8g6l" dur="8" oct="5" pname="d" stem.dir="down" />
+                              <note xml:id="nzij5rd" dur="8" oct="5" pname="e" stem.dir="down">
                                  <accid accid="n" />
                               </note>
                            </beam>
                         </layer>
                      </staff>
-                     <staff xml:id="m16s3" n="3">
-                        <layer xml:id="m16s3l1" n="1">
-                           <mRest xml:id="mc57pia" />
+                     <staff n="3">
+                        <layer n="1">
+                           <mRest />
                         </layer>
                      </staff>
-                     <staff xml:id="m16s4" n="4">
-                        <layer xml:id="m16s4l1" n="1">
-                           <mRest xml:id="m1ndf27s" />
+                     <staff n="4">
+                        <layer n="1">
+                           <mRest />
                         </layer>
                      </staff>
-                     <slur xml:id="soly3b7" startid="#n1iedk6n" curvedir="above" endid="#nmgjzbp" />
-                     <slur xml:id="sg46wcg" startid="#nbubu4b" curvedir="above" endid="#n1m4pb0s" />
-                     <slur xml:id="s1nz1m94" startid="#n1yjdt6u" curvedir="above" endid="#nm1bw5w" />
-                     <slur xml:id="s1edhe2v" startid="#n11i8g6l" curvedir="above" endid="#nzij5rd" />
+                     <slur startid="#n1iedk6n" endid="#nmgjzbp" curvedir="above" />
+                     <slur startid="#nbubu4b" endid="#n1m4pb0s" curvedir="above" />
+                     <slur startid="#n1yjdt6u" endid="#nm1bw5w" curvedir="above" />
+                     <slur startid="#n11i8g6l" endid="#nzij5rd" curvedir="above" />
                   </measure>
                </section>
             </score>

--- a/_tests/tab/tab-001.mei
+++ b/_tests/tab/tab-001.mei
@@ -1,243 +1,244 @@
-<?xml version="1.0" standalone="no"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>French lute tablature example</title>
-            </titleStmt>
-            <pubStmt>
-                <respStmt>
-                    <persName role="encoder">Olja Janjuš</persName>
-                </respStmt>
-                <date isodate="2024-12-04" />
-            </pubStmt>
-            <notesStmt>
-                <annot>Lute tablature rendering</annot>
-            </notesStmt>
-            <sourceDesc>
-                <source>
-                    <bibl>
-                        <title>A galliard made by Ed.J.</title>
-                        <title type="main">A new Booke of Tabliture for the Orpharion</title>
-                        <composer>Edward Johnson</composer>
-                        <arranger>William Barley</arranger>
-                        <date isodate="1596">1596</date>
-                        <locus>C1v</locus>
-                    </bibl>
-                </source>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-            <appInfo>
-                <application isodate="2022-09-26" version="1.4.5">
-                    <name>luteconv</name>
-                </application>
-            </appInfo>
-        </encodingDesc>
-        <workList>
-            <work>
-                <title>A galliard made by Ed.J.</title>
-                <composer>Edward Johnson</composer>
-            </work>
-        </workList>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv n="1">
-                <score>
-                    <scoreDef>
-                        <staffGrp>
-                            <staffDef n="1" lines="6" notationtype="tab.lute.french">
-                                <tuning>
-                                    <course n="1" pname="g" oct="4" />
-                                    <course n="2" pname="d" oct="4" />
-                                    <course n="3" pname="a" oct="3" />
-                                    <course n="4" pname="f" oct="3" />
-                                    <course n="5" pname="c" oct="3" />
-                                    <course n="6" pname="g" oct="2" />
-                                    <course n="7" pname="f" oct="2" />
-                                </tuning>
-                            </staffDef>
-                        </staffGrp>
-                    </scoreDef>
-                    <section n="1">
-                        <measure n="18">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <beam>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="4" tab.fret="0" />
-                                        </tabGrp>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="1" tab.fret="0" xml:id="id7" />
-                                        </tabGrp>
-                                    </beam>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="1" tab.fret="2" xml:id="id8" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id7" />
-                            <ornam ho="-2" startid="#id8">#</ornam>
-                        </measure>
-                        <measure n="19">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="2" />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="5" tab.fret="0" />
-                                    </tabGrp>
-                                    <beam>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="1" tab.fret="0" xml:id="id9" />
-                                        </tabGrp>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="5" tab.fret="2" />
-                                        </tabGrp>
-                                    </beam>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="5" tab.fret="3" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="2" startid="#id9" />
-                        </measure>
-                        <measure n="20">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="0" />
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="0" />
-                                        <note tab.course="6" tab.fret="3" />
-                                    </tabGrp>
-                                    <beam>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="5" tab.fret="2" xml:id="id10" />
-                                        </tabGrp>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="2" tab.fret="2" xml:id="id11" />
-                                        </tabGrp>
-                                    </beam>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="3" xml:id="id12" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id11" />
-                            <line startid="#id10" endid="#id12" />
-                        </measure>
-                        <measure n="21">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="4" tab.fret="0" />
-                                        <note tab.course="6" tab.fret="2" />
-                                    </tabGrp>
-                                    <beam>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="5" tab.fret="0" />
-                                        </tabGrp>
-                                        <tabGrp dur="16">
-                                            <tabDurSym />
-                                            <note tab.course="2" tab.fret="0" xml:id="id13" />
-                                        </tabGrp>
-                                    </beam>
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="1" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id13" />
-                        </measure>
-                        <measure n="22">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8" dots="1">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="1" />
-                                        <note tab.course="4" tab.fret="2" />
-                                        <note tab.course="6" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <tabDurSym />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="6" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <note tab.course="2" tab.fret="0" />
-                                        <note tab.course="6" tab.fret="3" />
-                                    </tabGrp>
-                                    <tabGrp dur="16">
-                                        <note tab.course="2" tab.fret="2" />
-                                        <note tab.course="5" tab.fret="0" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure n="23">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="0" />
-                                        <note tab.course="5" tab.fret="2" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="5" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="8">
-                                        <note tab.course="2" tab.fret="2" xml:id="id14" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fing playingHand="right" playingFinger="1" startid="#id14" />
-                        </measure>
-                        <measure n="24" right="rptend">
-                            <staff n="1">
-                                <layer n="1">
-                                    <tabGrp dur="8">
-                                        <tabDurSym />
-                                        <note tab.course="2" tab.fret="3" />
-                                        <note tab.course="3" tab.fret="3" />
-                                        <note tab.course="4" tab.fret="0" />
-                                    </tabGrp>
-                                    <tabGrp dur="4" xml:id="id15">
-                                        <tabDurSym />
-                                        <note tab.course="7" tab.fret="0" />
-                                    </tabGrp>
-                                </layer>
-                            </staff>
-                            <fermata startid="#id15" />
-                        </measure>
-                    </section>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>French lute tablature example</title>
+         </titleStmt>
+         <pubStmt>
+            <respStmt>
+               <persName role="encoder">Olja Janjuš</persName>
+            </respStmt>
+            <date isodate="2024-12-04" />
+         </pubStmt>
+         <notesStmt>
+            <annot>Lute tablature rendering</annot>
+         </notesStmt>
+         <sourceDesc>
+            <source>
+               <bibl>
+                  <title>A galliard made by Ed.J.</title>
+                  <title type="main">A new Booke of Tabliture for the Orpharion</title>
+                  <composer>Edward Johnson</composer>
+                  <arranger>William Barley</arranger>
+                  <date isodate="1596">1596</date>
+                  <locus>C1v</locus>
+               </bibl>
+            </source>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application isodate="2022-09-26" version="1.4.5">
+               <name>luteconv</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+      <workList>
+         <work>
+            <title>A galliard made by Ed.J.</title>
+            <composer>Edward Johnson</composer>
+         </work>
+      </workList>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv n="1">
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" notationtype="tab.lute.french" lines="6">
+                        <tuning>
+                           <course n="1" oct="4" pname="g" />
+                           <course n="2" oct="4" pname="d" />
+                           <course n="3" oct="3" pname="a" />
+                           <course n="4" oct="3" pname="f" />
+                           <course n="5" oct="3" pname="c" />
+                           <course n="6" oct="2" pname="g" />
+                           <course n="7" oct="2" pname="f" />
+                        </tuning>
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section n="1">
+                  <measure n="18">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <beam>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note tab.course="4" tab.fret="0" />
+                              </tabGrp>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note xml:id="id7" tab.course="1" tab.fret="0" />
+                              </tabGrp>
+                           </beam>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note xml:id="id8" tab.course="1" tab.fret="2" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id7" playingHand="right" playingFinger="1" />
+                     <ornam startid="#id8" ho="-2">#</ornam>
+                  </measure>
+                  <measure n="19">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="2" />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="5" tab.fret="0" />
+                           </tabGrp>
+                           <beam>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note xml:id="id9" tab.course="1" tab.fret="0" />
+                              </tabGrp>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note tab.course="5" tab.fret="2" />
+                              </tabGrp>
+                           </beam>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="5" tab.fret="3" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id9" playingHand="right" playingFinger="2" />
+                  </measure>
+                  <measure n="20">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="0" />
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="4" tab.fret="0" />
+                              <note tab.course="6" tab.fret="3" />
+                           </tabGrp>
+                           <beam>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note tab.course="5" tab.fret="2" />
+                              </tabGrp>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note xml:id="id11" tab.course="2" tab.fret="2" />
+                              </tabGrp>
+                           </beam>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="3" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id11" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure n="21">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="4" tab.fret="0" />
+                              <note tab.course="6" tab.fret="2" />
+                           </tabGrp>
+                           <beam>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note tab.course="5" tab.fret="0" />
+                              </tabGrp>
+                              <tabGrp dur="16">
+                                 <tabDurSym />
+                                 <note xml:id="id13" tab.course="2" tab.fret="0" />
+                              </tabGrp>
+                           </beam>
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="1" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id13" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure n="22">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dots="1" dur="8">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="1" />
+                              <note tab.course="4" tab.fret="2" />
+                              <note tab.course="6" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <tabDurSym />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="6" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <note tab.course="2" tab.fret="0" />
+                              <note tab.course="6" tab.fret="3" />
+                           </tabGrp>
+                           <tabGrp dur="16">
+                              <note tab.course="2" tab.fret="2" />
+                              <note tab.course="5" tab.fret="0" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="23">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="3" tab.fret="0" />
+                              <note tab.course="5" tab.fret="2" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="5" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp dur="8">
+                              <note xml:id="id14" tab.course="2" tab.fret="2" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fing startid="#id14" playingHand="right" playingFinger="1" />
+                  </measure>
+                  <measure right="rptend" n="24">
+                     <staff n="1">
+                        <layer n="1">
+                           <tabGrp dur="8">
+                              <tabDurSym />
+                              <note tab.course="2" tab.fret="3" />
+                              <note tab.course="3" tab.fret="3" />
+                              <note tab.course="4" tab.fret="0" />
+                           </tabGrp>
+                           <tabGrp xml:id="id15" dur="4">
+                              <tabDurSym />
+                              <note tab.course="7" tab.fret="0" />
+                           </tabGrp>
+                        </layer>
+                     </staff>
+                     <fermata startid="#id15" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-001.mei
+++ b/_tests/tie/tie-001.mei
@@ -1,143 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Tie example</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017">2017</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Verovio supports both ties encoded with "tie" attributes or with "tie" elements. Ties overlapping two measures and interrupted by a system break or a page break are displayed appropriately.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="0.9.13">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef meter.count="4" meter.unit="4">
-            <staffGrp label="Piano" symbol="brace" n="1">
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" keysig="1s" />
-              <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.mode="major" keysig="1s" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note dur="8" oct="4" pname="e" />
-                    <note dur="8" oct="4" pname="d" />
-                    <note dur="8" oct="4" pname="e" />
-                    <note xml:id="dd4n384v1b1s1" dur="8" oct="4" pname="d" tie="i" />
-                  </beam>
-                  <beam>
-                    <note xml:id="dd4n512v1b1s1" dur="8" oct="4" pname="d" tie="t" />
-                    <note dur="8" oct="4" pname="c" />
-                    <note dur="8" oct="4" pname="d" />
-                    <note xml:id="cd4n896v1b1s1" dur="8" oct="4" pname="c" tie="i" />
-                  </beam>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dur="4" oct="3" pname="c" />
-                  <note dur="4" oct="3" pname="c" />
-                  <note dur="4" oct="2" pname="b" />
-                  <note dur="4" oct="2" pname="b" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note xml:id="cd4n0v1b2s1" dur="8" oct="4" pname="c" tie="t" />
-                    <note dur="8" oct="3" pname="b" />
-                    <note dur="8" oct="4" pname="c" />
-                    <note xml:id="bd3n384v1b2s1" dur="8" oct="3" pname="b" tie="i" />
-                  </beam>
-                  <beam>
-                    <note xml:id="bd3n512v1b2s1" dur="8" oct="3" pname="b" tie="t" />
-                    <note dur="8" oct="4" pname="c" />
-                    <note dur="8" oct="4" pname="d" />
-                    <note xml:id="ed4n896v1b2s1" dur="8" oct="4" pname="e" tie="i" />
-                  </beam>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dur="4" oct="2" pname="a" />
-                  <note dur="4" oct="2" pname="a" />
-                  <note dur="2" oct="2" pname="g" />
-                </layer>
-              </staff>
-            </measure>
-            <sb />
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note xml:id="ed4n0v1b3s1" dur="8" oct="4" pname="e" tie="t" />
-                    <note dur="8" oct="4" pname="d" />
-                    <note dur="8" oct="4" pname="e" />
-                    <note xml:id="dd4n384v1b3s1" dur="8" oct="4" pname="d" tie="i" />
-                  </beam>
-                  <beam>
-                    <note xml:id="dd4n512v1b3s1" dur="8" oct="4" pname="d" tie="t" />
-                    <note dur="8" oct="4" pname="c" />
-                    <note dur="8" oct="4" pname="d" />
-                    <note xml:id="cd4n896v1b3s1" dur="8" oct="4" pname="c" tie="i" />
-                  </beam>
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dur="4" oct="3" pname="c" />
-                  <note dur="4" oct="3" pname="c" />
-                  <note dur="4" oct="2" pname="b" />
-                  <note dur="4" oct="2" pname="b" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="4">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note xml:id="cd4n0v1b4s1" dur="8" oct="4" pname="c" tie="t" />
-                    <note dur="8" oct="3" pname="b" />
-                    <note dur="8" oct="4" pname="c" />
-                    <note xml:id="bd3n384v1b4s1" dur="8" oct="3" pname="b" tie="i" />
-                  </beam>
-                  <note xml:id="bd3n512v1b4s1" dur="2" oct="3" pname="b" tie="t" />
-                </layer>
-              </staff>
-              <staff n="2">
-                <layer n="1">
-                  <note dur="4" oct="2" pname="a" />
-                  <note dur="4" oct="2" pname="a" />
-                  <note dur="4" oct="2" pname="g" />
-                  <note dur="4" oct="2" pname="g" />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Tie example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017">2017</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio supports both ties encoded with "tie" attributes or with "tie" elements. Ties overlapping two measures and interrupted by a system break or a page break are displayed appropriately.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="0.9.13">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="4" meter.unit="4">
+                  <staffGrp label="Piano" n="1" symbol="brace">
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" keysig="1s" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.mode="major" keysig="1s" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note dur="8" oct="4" pname="e" />
+                              <note dur="8" oct="4" pname="d" />
+                              <note dur="8" oct="4" pname="e" />
+                              <note xml:id="dd4n384v1b1s1" dur="8" oct="4" pname="d" tie="i" />
+                           </beam>
+                           <beam>
+                              <note xml:id="dd4n512v1b1s1" dur="8" oct="4" pname="d" tie="t" />
+                              <note dur="8" oct="4" pname="c" />
+                              <note dur="8" oct="4" pname="d" />
+                              <note xml:id="cd4n896v1b1s1" dur="8" oct="4" pname="c" tie="i" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="c" />
+                           <note dur="4" oct="3" pname="c" />
+                           <note dur="4" oct="2" pname="b" />
+                           <note dur="4" oct="2" pname="b" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="cd4n0v1b2s1" dur="8" oct="4" pname="c" tie="t" />
+                              <note dur="8" oct="3" pname="b" />
+                              <note dur="8" oct="4" pname="c" />
+                              <note xml:id="bd3n384v1b2s1" dur="8" oct="3" pname="b" tie="i" />
+                           </beam>
+                           <beam>
+                              <note xml:id="bd3n512v1b2s1" dur="8" oct="3" pname="b" tie="t" />
+                              <note dur="8" oct="4" pname="c" />
+                              <note dur="8" oct="4" pname="d" />
+                              <note xml:id="ed4n896v1b2s1" dur="8" oct="4" pname="e" tie="i" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="2" pname="a" />
+                           <note dur="4" oct="2" pname="a" />
+                           <note dur="2" oct="2" pname="g" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <sb />
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="ed4n0v1b3s1" dur="8" oct="4" pname="e" tie="t" />
+                              <note dur="8" oct="4" pname="d" />
+                              <note dur="8" oct="4" pname="e" />
+                              <note xml:id="dd4n384v1b3s1" dur="8" oct="4" pname="d" tie="i" />
+                           </beam>
+                           <beam>
+                              <note xml:id="dd4n512v1b3s1" dur="8" oct="4" pname="d" tie="t" />
+                              <note dur="8" oct="4" pname="c" />
+                              <note dur="8" oct="4" pname="d" />
+                              <note xml:id="cd4n896v1b3s1" dur="8" oct="4" pname="c" tie="i" />
+                           </beam>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="3" pname="c" />
+                           <note dur="4" oct="3" pname="c" />
+                           <note dur="4" oct="2" pname="b" />
+                           <note dur="4" oct="2" pname="b" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="cd4n0v1b4s1" dur="8" oct="4" pname="c" tie="t" />
+                              <note dur="8" oct="3" pname="b" />
+                              <note dur="8" oct="4" pname="c" />
+                              <note xml:id="bd3n384v1b4s1" dur="8" oct="3" pname="b" tie="i" />
+                           </beam>
+                           <note xml:id="bd3n512v1b4s1" dur="2" oct="3" pname="b" tie="t" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <note dur="4" oct="2" pname="a" />
+                           <note dur="4" oct="2" pname="a" />
+                           <note dur="4" oct="2" pname="g" />
+                           <note dur="4" oct="2" pname="g" />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-004.mei
+++ b/_tests/tie/tie-004.mei
@@ -1,104 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Ties on chords example</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017">2017</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>Verovio determines the tie direction looking at the context (layer, stem direction, chord, etc.). Collision with stem is normally avoided except with short ties and when the context does allow do to so.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="0.9.13">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef meter.count="4" meter.unit="4">
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1" label="1">
-              <staff n="1">
-                <layer n="1">
-                  <rest dur="8" />
-                  <note xml:id="note-0000000533095021" dur="8" oct="4" pname="b" tie="i" />
-                  <note xml:id="note-0000000426242663" dur="2" oct="4" pname="b" tie="t" />
-                  <chord dur="4" tie="i">
-                    <note xml:id="note-0000000221777088" dur="4" oct="4" pname="e" tie="i" />
-                    <note xml:id="note-0000001523390471" dur="4" oct="4" pname="g" tie="i" />
-                    <note xml:id="note-0000001323606563" dur="4" oct="4" pname="b" tie="i" />
-                    <note xml:id="note-0000000072405068" dur="4" oct="5" pname="d" tie="i" />
-                    <note xml:id="note-0000001436233674" dur="4" oct="5" pname="f" tie="i" />
-                  </chord>
-                </layer>
-                <layer n="2">
-                  <space dur="8" />
-                  <note xml:id="note-0000002126280073" dur="8" oct="4" pname="g" tie="i" />
-                  <note xml:id="note-0000000113817184" dur="2" oct="4" pname="g" tie="t" />
-                  <space dur="4" />
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2" tie="t">
-                    <note xml:id="note-0000000569453428" dur="4" oct="4" pname="e" tie="t" />
-                    <note xml:id="note-0000001616633364" dur="4" oct="4" pname="g" tie="t" />
-                    <note xml:id="note-0000000793846904" dur="4" oct="4" pname="b" tie="t" />
-                    <note xml:id="note-0000002016500364" dur="4" oct="5" pname="d" tie="t" />
-                    <note xml:id="note-0000001882184441" dur="4" oct="5" pname="f" tie="t" />
-                  </chord>
-                  <chord dur="2">
-                    <note xml:id="n01" dur="4" oct="4" pname="e" />
-                    <note xml:id="n02" dur="4" oct="4" pname="g" />
-                    <note xml:id="n03" dur="4" oct="4" pname="b" />
-                    <note xml:id="n04" dur="4" oct="5" pname="d" />
-                    <note xml:id="n05" dur="4" oct="5" pname="f" />
-                  </chord>
-                </layer>
-              </staff>
-              <tie startid="#n01" endid="#n06" />
-              <tie startid="#n02" endid="#n07" />
-              <tie startid="#n03" endid="#n08" />
-              <tie startid="#n04" endid="#n09" />
-              <tie startid="#n05" endid="#n10" />
-            </measure>
-            <measure right="end" n="3">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2">
-                    <note xml:id="n06" dur="4" oct="4" pname="e" />
-                    <note xml:id="n07" dur="4" oct="4" pname="g" />
-                    <note xml:id="n08" dur="4" oct="4" pname="b" />
-                    <note xml:id="n09" dur="4" oct="5" pname="d" />
-                    <note xml:id="n10" dur="4" oct="5" pname="f" />
-                  </chord>
-                  <rest dur="2" />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Ties on chords example</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017">2017</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>Verovio determines the tie direction looking at the context (layer, stem direction, chord, etc.). Collision with stem is normally avoided except with short ties and when the context does allow do to so.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="0.9.13">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef meter.count="4" meter.unit="4">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1" label="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <rest dur="8" />
+                           <note xml:id="note-0000000533095021" dur="8" oct="4" pname="b" tie="i" />
+                           <note xml:id="note-0000000426242663" dur="2" oct="4" pname="b" tie="t" />
+                           <chord dur="4" tie="i">
+                              <note xml:id="note-0000000221777088" dur="4" oct="4" pname="e" tie="i" />
+                              <note xml:id="note-0000001523390471" dur="4" oct="4" pname="g" tie="i" />
+                              <note xml:id="note-0000001323606563" dur="4" oct="4" pname="b" tie="i" />
+                              <note xml:id="note-0000000072405068" dur="4" oct="5" pname="d" tie="i" />
+                              <note xml:id="note-0000001436233674" dur="4" oct="5" pname="f" tie="i" />
+                           </chord>
+                        </layer>
+                        <layer n="2">
+                           <space dur="8" />
+                           <note xml:id="note-0000002126280073" dur="8" oct="4" pname="g" tie="i" />
+                           <note xml:id="note-0000000113817184" dur="2" oct="4" pname="g" tie="t" />
+                           <space dur="4" />
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2" tie="t">
+                              <note xml:id="note-0000000569453428" dur="4" oct="4" pname="e" tie="t" />
+                              <note xml:id="note-0000001616633364" dur="4" oct="4" pname="g" tie="t" />
+                              <note xml:id="note-0000000793846904" dur="4" oct="4" pname="b" tie="t" />
+                              <note xml:id="note-0000002016500364" dur="4" oct="5" pname="d" tie="t" />
+                              <note xml:id="note-0000001882184441" dur="4" oct="5" pname="f" tie="t" />
+                           </chord>
+                           <chord dur="2">
+                              <note xml:id="n01" dur="4" oct="4" pname="e" />
+                              <note xml:id="n02" dur="4" oct="4" pname="g" />
+                              <note xml:id="n03" dur="4" oct="4" pname="b" />
+                              <note xml:id="n04" dur="4" oct="5" pname="d" />
+                              <note xml:id="n05" dur="4" oct="5" pname="f" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <tie startid="#n01" endid="#n06" />
+                     <tie startid="#n02" endid="#n07" />
+                     <tie startid="#n03" endid="#n08" />
+                     <tie startid="#n04" endid="#n09" />
+                     <tie startid="#n05" endid="#n10" />
+                  </measure>
+                  <measure right="end" n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2">
+                              <note xml:id="n06" dur="4" oct="4" pname="e" />
+                              <note xml:id="n07" dur="4" oct="4" pname="g" />
+                              <note xml:id="n08" dur="4" oct="4" pname="b" />
+                              <note xml:id="n09" dur="4" oct="5" pname="d" />
+                              <note xml:id="n10" dur="4" oct="5" pname="f" />
+                           </chord>
+                           <rest dur="2" />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tie/tie-005.mei
+++ b/_tests/tie/tie-005.mei
@@ -1,91 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
-  <meiHead>
-    <fileDesc>
-      <titleStmt>
-        <title>Tie attributes on chords</title>
-      </titleStmt>
-      <pubStmt>
-        <date isodate="2017">2017</date>
-      </pubStmt>
-      <seriesStmt>
-        <title>Verovio test suite</title>
-      </seriesStmt>
-      <notesStmt>
-        <annot>With chords, the "tie" attribute can be set in the chord or in the notes. It can also be overwritten in the note if necessary.</annot>
-      </notesStmt>
-    </fileDesc>
-    <encodingDesc>
-      <appInfo>
-        <application version="0.9.13">
-          <name>Verovio</name>
-        </application>
-      </appInfo>
-    </encodingDesc>
-  </meiHead>
-  <music>
-    <body>
-      <mdiv>
-        <score>
-          <scoreDef>
-            <staffGrp>
-              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-            </staffGrp>
-          </scoreDef>
-          <section>
-            <measure n="1">
-              <staff n="1">
-                <layer n="1">
-                  <rest dur="16" />
-                  <beam>
-                    <note xml:id="n1" dur="16" oct="4" pname="c" tie="i" />
-                    <note xml:id="n2" dur="16" oct="4" pname="e" tie="i" />
-                    <note xml:id="n3" dur="16" oct="4" pname="g" tie="i" />
-                  </beam>
-                </layer>
-              </staff>
-            </measure>
-            <measure n="2">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2" tie="m">
-                    <note xml:id="n6" dur="8" oct="4" pname="c" />
-                    <note xml:id="n7" dur="8" oct="4" pname="e" />
-                    <note xml:id="n8" dur="8" oct="4" pname="g" />
-                    <note xml:id="n9" dur="8" oct="5" pname="c" tie="i" />
-                  </chord>
-                </layer>
-              </staff>
-            </measure>
-            <measure n="3">
-              <staff n="1">
-                <layer n="1">
-                  <chord dur="2" tie="m">
-                    <note xml:id="n11" dur="8" oct="4" pname="c" />
-                    <note xml:id="n12" dur="8" oct="4" pname="e" />
-                    <note xml:id="n13" dur="8" oct="4" pname="g" />
-                    <note xml:id="n14" dur="8" oct="5" pname="c" tie="t" />
-                  </chord>
-                </layer>
-              </staff>
-            </measure>
-            <measure right="invis" n="4">
-              <staff n="1">
-                <layer n="1">
-                  <beam>
-                    <note xml:id="n17" dur="16" oct="4" pname="g" tie="t" />
-                    <note xml:id="n18" dur="16" oct="4" pname="e" tie="t" />
-                    <note xml:id="n19" dur="16" oct="4" pname="c" tie="t" />
-                  </beam>
-                  <rest dur="16" />
-                </layer>
-              </staff>
-            </measure>
-          </section>
-        </score>
-      </mdiv>
-    </body>
-  </music>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Tie attributes on chords</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2017">2017</date>
+         </pubStmt>
+         <seriesStmt>
+            <title>Verovio test suite</title>
+         </seriesStmt>
+         <notesStmt>
+            <annot>With chords, the "tie" attribute can be set in the chord or in the notes. It can also be overwritten in the note if necessary.</annot>
+         </notesStmt>
+      </fileDesc>
+      <encodingDesc>
+         <appInfo>
+            <application version="0.9.13">
+               <name>Verovio</name>
+            </application>
+         </appInfo>
+      </encodingDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+                  </staffGrp>
+               </scoreDef>
+               <section>
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <rest dur="16" />
+                           <beam>
+                              <note xml:id="n1" dur="16" oct="4" pname="c" tie="i" />
+                              <note xml:id="n2" dur="16" oct="4" pname="e" tie="i" />
+                              <note xml:id="n3" dur="16" oct="4" pname="g" tie="i" />
+                           </beam>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2" tie="m">
+                              <note xml:id="n6" dur="8" oct="4" pname="c" />
+                              <note xml:id="n7" dur="8" oct="4" pname="e" />
+                              <note xml:id="n8" dur="8" oct="4" pname="g" />
+                              <note xml:id="n9" dur="8" oct="5" pname="c" tie="i" />
+                           </chord>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <chord dur="2" tie="m">
+                              <note xml:id="n11" dur="8" oct="4" pname="c" />
+                              <note xml:id="n12" dur="8" oct="4" pname="e" />
+                              <note xml:id="n13" dur="8" oct="4" pname="g" />
+                              <note xml:id="n14" dur="8" oct="5" pname="c" tie="t" />
+                           </chord>
+                        </layer>
+                     </staff>
+                  </measure>
+                  <measure right="invis" n="4">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="n17" dur="16" oct="4" pname="g" tie="t" />
+                              <note xml:id="n18" dur="16" oct="4" pname="e" tie="t" />
+                              <note xml:id="n19" dur="16" oct="4" pname="c" tie="t" />
+                           </beam>
+                           <rest dur="16" />
+                        </layer>
+                     </staff>
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
 </mei>

--- a/_tests/tuplet/tuplet-020.mei
+++ b/_tests/tuplet/tuplet-020.mei
@@ -34,61 +34,61 @@
    </meiHead>
    <music>
       <body>
-         <mdiv xml:id="mdiv-0000002140519904">
-            <score xml:id="score-0000001247944073">
-               <scoreDef xml:id="scoredef-0000001464122233">
-                  <staffGrp xml:id="staffgrp-0000000515865295" symbol="brace" bar.thru="true">
-                     <labelAbbr xml:id="labelAbbr-0000001059544640" />
-                     <staffDef xml:id="staffdef-0000000738709609" clef.shape="G" clef.line="2" meter.count="3" meter.unit="4" n="1" lines="5" />
-                     <staffDef xml:id="staffdef-0000000476248232" clef.shape="F" clef.line="4" meter.count="3" meter.unit="4" n="2" lines="5" />
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp bar.thru="true" symbol="brace">
+                     <labelAbbr />
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="3" meter.unit="4" />
+                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" meter.count="3" meter.unit="4" />
                   </staffGrp>
                </scoreDef>
-               <section xml:id="section-L1F1">
-                  <measure xml:id="measure-L1" n="0">
-                     <staff xml:id="staff-0000002039255049" n="1">
-                        <layer xml:id="layer-L1F2N1" n="1">
-                           <tuplet xml:id="tuplet-L5F2-L7F2" num="3" numbase="2" num.format="count">
-                              <note xml:id="note-L5F2" dur="8" staff="2" oct="3" pname="c" stem.dir="up" accid.ges="n" />
-                              <note xml:id="note-L6F2" dur="8" staff="2" oct="2" pname="b" stem.dir="up" accid.ges="n" />
-                              <note xml:id="note-L7F2" dur="8" staff="2" oct="2" pname="a" stem.dir="up" accid.ges="n" />
+               <section>
+                  <measure n="0">
+                     <staff n="1">
+                        <layer n="1">
+                           <tuplet num="3" numbase="2" num.format="count">
+                              <note dur="8" staff="2" oct="3" pname="c" stem.dir="up" accid.ges="n" />
+                              <note dur="8" staff="2" oct="2" pname="b" stem.dir="up" accid.ges="n" />
+                              <note dur="8" staff="2" oct="2" pname="a" stem.dir="up" accid.ges="n" />
                            </tuplet>
-                           <rest xml:id="rest-L8F2" dur="4" />
-                           <tuplet xml:id="tuplet-L9F2-L11F2" num="3" numbase="2" bracket.visible="false" num.format="count">
-                              <beam xml:id="beam-L9F2-L11F2" beam.with="below">
-                                 <note xml:id="note-L9F2" dur="8" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="n" />
-                                 <note xml:id="note-L10F2" dur="8" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="n" />
-                                 <note xml:id="note-L11F2" dur="8" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="n" />
+                           <rest dur="4" />
+                           <tuplet num="3" numbase="2" bracket.visible="false" num.format="count">
+                              <beam beam.with="below">
+                                 <note dur="8" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="n" />
+                                 <note dur="8" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="n" />
+                                 <note dur="8" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                               </beam>
                            </tuplet>
                         </layer>
                      </staff>
-                     <staff xml:id="staff-0000001940974881" n="2">
-                        <layer xml:id="layer-L1F1N1" n="1">
-                           <mRest xml:id="mrest-L5F1" ploc="g" oloc="2" />
+                     <staff n="2">
+                        <layer n="1">
+                           <mRest ploc="g" oloc="2" />
                         </layer>
                      </staff>
                   </measure>
-                  <measure xml:id="measure-L12">
-                     <staff xml:id="staff-L12F2N1" n="1">
-                        <layer xml:id="layer-L12F2N1" n="1">
-                           <tuplet xml:id="tuplet-L13F2-L15F2" num="3" numbase="2" bracket.visible="false" num.format="count">
-                              <beam xml:id="beam-L13F2-L15F2">
-                                 <note xml:id="note-L13F2" dur="8" oct="5" pname="e" stem.dir="up" accid.ges="n" />
-                                 <note xml:id="note-L14F2" dur="8" oct="5" pname="d" accid.ges="n" />
-                                 <note xml:id="note-L15F2" dur="8" oct="5" pname="c" accid.ges="n" />
+                  <measure>
+                     <staff n="1">
+                        <layer n="1">
+                           <tuplet num="3" numbase="2" bracket.visible="false" num.format="count">
+                              <beam>
+                                 <note dur="8" oct="5" pname="e" stem.dir="up" accid.ges="n" />
+                                 <note dur="8" oct="5" pname="d" accid.ges="n" />
+                                 <note dur="8" oct="5" pname="c" accid.ges="n" />
                               </beam>
                            </tuplet>
-                           <rest xml:id="rest-L16F2" dur="4" />
-                           <tuplet xml:id="tuplet-L17F2-L19F2" num="3" numbase="2" num.format="count">
-                              <note xml:id="note-L17F2" dur="8" oct="4" pname="a" accid.ges="n" />
-                              <note xml:id="note-L18F2" dur="8" oct="4" pname="g" accid.ges="n" />
-                              <note xml:id="note-L19F2" dur="8" oct="4" pname="f" accid.ges="n" />
+                           <rest dur="4" />
+                           <tuplet num="3" numbase="2" num.format="count">
+                              <note dur="8" oct="4" pname="a" accid.ges="n" />
+                              <note dur="8" oct="4" pname="g" accid.ges="n" />
+                              <note dur="8" oct="4" pname="f" accid.ges="n" />
                            </tuplet>
                         </layer>
                      </staff>
-                     <staff xml:id="staff-L12F1N1" n="2">
-                        <layer xml:id="layer-L12F1N1" n="1">
-                           <mRest xml:id="mrest-L13F1" ploc="g" oloc="2" />
+                     <staff n="2">
+                        <layer n="1">
+                           <mRest ploc="g" oloc="2" />
                         </layer>
                      </staff>
                   </measure>

--- a/_tests/turn/turn-002.mei
+++ b/_tests/turn/turn-002.mei
@@ -51,7 +51,7 @@
                            </beam>
                         </layer>
                      </staff>
-                     <turn label="delayed turn" staff="1" tstamp="2.660000" accidlower="s" place="above" delayed="true" />
+                     <turn label="delayed turn" staff="1" tstamp="2.66" accidlower="s" place="above" delayed="true" />
                   </measure>
                </section>
             </score>


### PR DESCRIPTION
`score-015.mei` and `tuplet-020.mei` are losing a lot of IDs, but on looking over these I think it's fine to drop them.
Also two examples change the rng from `mei-Mensural` to `mei-all`.